### PR TITLE
Update VerifyKZGProof params to match spec

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -61,16 +61,16 @@ func TestNonCanonicalSmoke(t *testing.T) {
 		t.Errorf("expected an error since blob was not canonical")
 	}
 
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPointGood, claimedValueGood)
+	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), inputPointGood, claimedValueGood, proof)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPointGood, claimedValueBad)
+	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), inputPointGood, claimedValueBad, proof)
 	if err == nil {
 		t.Errorf("expected an error since claimed value was not canonical")
 	}
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPointBad, claimedValueGood)
+	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), inputPointBad, claimedValueGood, proof)
 	if err == nil {
 		t.Errorf("expected an error since input point was not canonical")
 	}

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -88,7 +88,7 @@ func Benchmark(b *testing.B) {
 
 	b.Run("VerifyKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_ = ctx.VerifyKZGProof(serialization.KZGCommitment(commitments[0]), proofs[0], fields[0], fields[1])
+			_ = ctx.VerifyKZGProof(serialization.KZGCommitment(commitments[0]), fields[0], fields[1], proofs[0])
 		}
 	})
 

--- a/api/consensus_specs_test.go
+++ b/api/consensus_specs_test.go
@@ -258,7 +258,7 @@ func TestVerifyKZGProof(t *testing.T) {
 				}
 				return
 			}
-			err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), serialization.KZGProof(proof), z, y)
+			err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), z, y, serialization.KZGProof(proof))
 			// Test specifically distinguish between the test failing
 			// because of the pairing check and failing because of
 			// validation errors

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -38,7 +38,7 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPoint, claimedValue)
+	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), inputPoint, claimedValue, proof)
 	if err != nil {
 		t.Error(err)
 	}

--- a/api/verify.go
+++ b/api/verify.go
@@ -8,7 +8,7 @@ import (
 )
 
 // [verify_kzg_proof](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#verify_kzg_proof)
-func (c *Context) VerifyKZGProof(blobCommitment serialization.KZGCommitment, kzgProof serialization.KZGProof, inputPointBytes, claimedValueBytes serialization.Scalar) error {
+func (c *Context) VerifyKZGProof(blobCommitment serialization.KZGCommitment, inputPointBytes, claimedValueBytes serialization.Scalar, kzgProof serialization.KZGProof) error {
 	// 1. Deserialization
 	//
 	claimedValue, err := serialization.DeserializeScalar(claimedValueBytes)


### PR DESCRIPTION
To match [the spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_kzg_proof), `proof` should be the last parameter.