### PR TITLE
Fix some IDE warnings

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -61,16 +61,16 @@ func TestNonCanonicalSmoke(t *testing.T) {
 		t.Errorf("expected an error since blob was not canonical")
 	}
 
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPointGood, claimedValueGood)
+	err = ctx.VerifyKZGProof(commitment, proof, inputPointGood, claimedValueGood)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPointGood, claimedValueBad)
+	err = ctx.VerifyKZGProof(commitment, proof, inputPointGood, claimedValueBad)
 	if err == nil {
 		t.Errorf("expected an error since claimed value was not canonical")
 	}
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPointBad, claimedValueGood)
+	err = ctx.VerifyKZGProof(commitment, proof, inputPointBad, claimedValueGood)
 	if err == nil {
 		t.Errorf("expected an error since input point was not canonical")
 	}

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -88,7 +88,7 @@ func Benchmark(b *testing.B) {
 
 	b.Run("VerifyKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_ = ctx.VerifyKZGProof(serialization.KZGCommitment(commitments[0]), proofs[0], fields[0], fields[1])
+			_ = ctx.VerifyKZGProof(commitments[0], proofs[0], fields[0], fields[1])
 		}
 	})
 

--- a/api/consensus_specs_test.go
+++ b/api/consensus_specs_test.go
@@ -258,7 +258,7 @@ func TestVerifyKZGProof(t *testing.T) {
 				}
 				return
 			}
-			err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), serialization.KZGProof(proof), z, y)
+			err = ctx.VerifyKZGProof(commitment, serialization.KZGProof(proof), z, y)
 			// Test specifically distinguish between the test failing
 			// because of the pairing check and failing because of
 			// validation errors

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -38,7 +38,7 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = ctx.VerifyKZGProof(serialization.KZGCommitment(commitment), proof, inputPoint, claimedValue)
+	err = ctx.VerifyKZGProof(commitment, proof, inputPoint, claimedValue)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/kzg/domain.go
+++ b/internal/kzg/domain.go
@@ -56,7 +56,10 @@ func NewDomain(x uint64) *Domain {
 	// Generator of the largest 2-adic subgroup.
 	// This particular element has order 2^maxOrderRoot == 2^32.
 	var rootOfUnity fr.Element
-	rootOfUnity.SetString("10238227357739495823651030575849232062558860180284477541189508159991286009131")
+	_, err := rootOfUnity.SetString("10238227357739495823651030575849232062558860180284477541189508159991286009131")
+	if err != nil {
+		panic("failed to initialize root of unity")
+	}
 	const maxOrderRoot uint64 = 32
 
 	// Find generator subgroup of order x.
@@ -71,7 +74,7 @@ func NewDomain(x uint64) *Domain {
 
 	// Store Inverse of the generator and inverse of the domain size (as field elements).
 	domain.GeneratorInv.Inverse(&domain.Generator)
-	domain.CardinalityInv.SetUint64(uint64(x))
+	domain.CardinalityInv.SetUint64(x)
 	domain.CardinalityInv.Inverse(&domain.CardinalityInv)
 
 	// Compute all relevant roots of unity, i.e. the multiplicative subgroup of size x.

--- a/internal/kzg/errors.go
+++ b/internal/kzg/errors.go
@@ -6,8 +6,6 @@ var (
 	ErrInvalidNumDigests              = errors.New("number of digests is not the same as the number of polynomials")
 	ErrInvalidPolynomialSize          = errors.New("invalid polynomial size (larger than SRS or == 0)")
 	ErrVerifyOpeningProof             = errors.New("can't verify opening proof")
-	ErrVerifyBatchOpeningSinglePoint  = errors.New("can't verify batch opening proof at single point")
 	ErrPolynomialMismatchedSizeDomain = errors.New("domain size does not equal the number of evaluations in the polynomial")
 	ErrMinSRSSize                     = errors.New("minimum srs size is 2")
-	ErrSRSPow2                        = errors.New("srs size must be a power of 2")
 )

--- a/internal/kzg/fft.go
+++ b/internal/kzg/fft.go
@@ -102,8 +102,8 @@ func fftG1(values []bls12381.G1Affine, nthRootOfUnity fr.Element) []bls12381.G1A
 // This is the case for a radix-2 FFT
 func takeEvenOdd[T interface{}](values []T) ([]T, []T) {
 	n := len(values)
-	var even []T = make([]T, 0, n/2)
-	var odd []T = make([]T, 0, n/2)
+	var even = make([]T, 0, n/2)
+	var odd = make([]T, 0, n/2)
 	for i := 0; i < n; i++ {
 		if i%2 == 0 {
 			even = append(even, values[i])

--- a/internal/multiexp/multiexp_test.go
+++ b/internal/multiexp/multiexp_test.go
@@ -95,7 +95,7 @@ func slowMultiExp(scalars []fr.Element, points []bls12381.G1Affine) (*bls12381.G
 	for i := 0; i < n; i++ {
 		var tmp bls12381.G1Affine
 		var bi big.Int
-		tmp.ScalarMultiplication(&points[i], scalars[i].ToBigIntRegular(&bi))
+		tmp.ScalarMultiplication(&points[i], scalars[i].BigInt(&bi))
 
 		result.Add(&result, &tmp)
 	}


### PR DESCRIPTION
All of these came from IntelliJ:

* Remove unnecessary casts.
* Handle error when initializing root of unity.
  * It would never error, but doesn't hurt to check.
* Remove unused errors.
* Replace `ToBigIntRegular` with not-deprecated one.
* Remove unnecessary types from declarations. 