### PR TITLE
Run gofumpt on everything

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,7 +37,7 @@ func NewContext4096Insecure1337() (*Context, error) {
 		panic("this method is named `NewContext4096Insecure1337` we expect SCALARS_PER_BLOB to be 4096")
 	}
 
-	var parsedSetup = JSONTrustedSetup{}
+	parsedSetup := JSONTrustedSetup{}
 
 	err := json.Unmarshal([]byte(testKzgSetupStr), &parsedSetup)
 	if err != nil {

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -37,13 +37,13 @@ func GetRandBlob(seed int64) serialization.Blob {
 var ctxG *api.Context
 
 func BenchmarkSetup(b *testing.B) {
-
 	ctx, err := api.NewContext4096Insecure1337()
 	if err != nil {
 		panic(err)
 	}
 	ctxG = ctx
 }
+
 func Benchmark(b *testing.B) {
 	const length = 64
 	blobs := make([]serialization.Blob, length)
@@ -112,7 +112,6 @@ func Benchmark(b *testing.B) {
 			}
 		})
 	}
-
 }
 
 func requireNoError(err error) {

--- a/api/consensus_specs_test.go
+++ b/api/consensus_specs_test.go
@@ -444,6 +444,7 @@ func hexStrToBlob(hexStr string) (serialization.Blob, error) {
 	copy(blob[:], byts)
 	return blob, nil
 }
+
 func hexStrToScalar(hexStr string) (serialization.Scalar, error) {
 	var scalar serialization.Scalar
 	byts, err := hexStrToBytes(hexStr)
@@ -457,9 +458,11 @@ func hexStrToScalar(hexStr string) (serialization.Scalar, error) {
 	copy(scalar[:], byts)
 	return scalar, nil
 }
+
 func hexStrToCommitment(hexStr string) (serialization.KZGCommitment, error) {
 	return hexStrToG1Point(hexStr)
 }
+
 func hexStrToG1Point(hexStr string) (serialization.G1Point, error) {
 	var point serialization.G1Point
 	byts, err := hexStrToBytes(hexStr)

--- a/api/errors.go
+++ b/api/errors.go
@@ -2,5 +2,7 @@ package api
 
 import "errors"
 
-var ErrBatchLengthCheck = errors.New("the number of blobs, commitments, and proofs must be the same")
-var errLagrangeMonomialLengthMismatch = errors.New("the number of points in monomial SRS should equal number of points in lagrange SRS")
+var (
+	ErrBatchLengthCheck               = errors.New("the number of blobs, commitments, and proofs must be the same")
+	errLagrangeMonomialLengthMismatch = errors.New("the number of points in monomial SRS should equal number of points in lagrange SRS")
+)

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -26,6 +26,7 @@ func TestBlobProveVerifyRandomPointIntegration(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 	blob := GetRandBlob(123)
 
@@ -43,8 +44,8 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 		t.Error(err)
 	}
 }
-func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 
+func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 	batchSize := 5
 
 	blobs := make([]serialization.Blob, batchSize)

--- a/api/trusted_setup.go
+++ b/api/trusted_setup.go
@@ -3,10 +3,9 @@ package api
 import (
 	"bytes"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"sync"
-
-	"encoding/hex"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/crate-crypto/go-proto-danksharding-crypto/internal/kzg"
@@ -36,13 +35,11 @@ type G1CompressedHexStr = string
 // Hex string for a compressed G2 point without the `0x` prefix
 type G2CompressedHexStr = string
 
-var (
-	// This is the test trusted setup, which SHOULD NOT BE USED IN PRODUCTION.
-	// The secret for this 1337.
-	//
-	//go:embed trusted_setup.json
-	testKzgSetupStr string
-)
+// This is the test trusted setup, which SHOULD NOT BE USED IN PRODUCTION.
+// The secret for this 1337.
+//
+//go:embed trusted_setup.json
+var testKzgSetupStr string
 
 // CheckTrustedSetupIsWellFormed Checks whether the trusted setup is well-formed.
 // This checks that:
@@ -51,7 +48,6 @@ var (
 // - All elements are in the correct subgroup
 // - Lagrange G1 points are obtained by doing an IFFT of monomial G1 points
 func CheckTrustedSetupIsWellFormed(trustedSetup *JSONTrustedSetup) error {
-
 	if len(trustedSetup.SetupG1) != len(trustedSetup.SetupG1Lagrange) {
 		return errLagrangeMonomialLengthMismatch
 	}
@@ -139,7 +135,6 @@ func parseG1PointNoSubgroupCheck(hexString string) (bls12381.G1Affine, error) {
 	d := bls12381.NewDecoder(bytes.NewReader(byts), noSubgroupCheck)
 
 	return point, d.Decode(&point)
-
 }
 
 // parseG2PointNoSubgroupCheck parses a hex-string (without 0x prefix) into a G2 point.

--- a/api/trusted_setup_test.go
+++ b/api/trusted_setup_test.go
@@ -6,8 +6,7 @@ import (
 )
 
 func TestTransformTrustedSetup(t *testing.T) {
-
-	var parsedSetup = JSONTrustedSetup{}
+	parsedSetup := JSONTrustedSetup{}
 
 	err := json.Unmarshal([]byte(testKzgSetupStr), &parsedSetup)
 	if err != nil {

--- a/internal/kzg/domain_test.go
+++ b/internal/kzg/domain_test.go
@@ -105,7 +105,7 @@ func TestEvalPolynomialSmoke(t *testing.T) {
 	// `domain`
 	lagrangePoly := make([]fr.Element, domain.Cardinality)
 	for i := 0; i < int(domain.Cardinality); i++ {
-		var x = domain.Roots[i]
+		x := domain.Roots[i]
 		lagrangePoly[i] = f_x(x)
 	}
 

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -75,7 +75,6 @@ func (domain *Domain) computeQuotientPoly(f Polynomial, indexInDomain int64, fz,
 // This is the implementation of [computeQuotientPoly] for the case where z is not in the domain.
 // Since both input and output polynomials are given in evaluation form, this method just performs the desired operation pointwise.
 func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.Element) ([]fr.Element, error) {
-
 	// Compute the lagrange form the of the numerator f(X) - f(z)
 	// Since f(X) is already in lagrange form, we can compute f(X) - f(z)
 	// by shifting all elements in f(X) by f(z)

--- a/internal/kzg/kzg_test.go
+++ b/internal/kzg/kzg_test.go
@@ -53,13 +53,12 @@ func TestBatchVerifySmoke(t *testing.T) {
 }
 
 func TestComputeQuotientPolySmoke(t *testing.T) {
-
 	numEvaluations := 128
 	domain := NewDomain(uint64(numEvaluations))
 
 	polyLagrange := randPoly(t, *domain)
 
-	polyEqual := func(lhs []fr.Element, rhs []fr.Element) bool {
+	polyEqual := func(lhs, rhs []fr.Element) bool {
 		for i := 0; i < int(domain.Cardinality); i++ {
 			if !lhs[i].Equal(&rhs[i]) {
 				return false
@@ -136,6 +135,7 @@ func computeQuotientPolySlow(domain Domain, f Polynomial, z fr.Element) ([]fr.El
 
 	return quotient, nil
 }
+
 func compute_quotient_eval_within_domain(domain Domain, z fr.Element, polynomial []fr.Element, y fr.Element) fr.Element {
 	var result fr.Element
 	for i := 0; i < int(domain.Cardinality); i++ {
@@ -161,7 +161,7 @@ func compute_quotient_eval_within_domain(domain Domain, z fr.Element, polynomial
 }
 
 func randValidOpeningProof(t *testing.T, domain Domain, srs SRS) (OpeningProof, Commitment) {
-	var poly = randPoly(t, domain)
+	poly := randPoly(t, domain)
 	comm, _ := Commit(poly, &srs.CommitKey)
 	point := samplePointOutsideDomain(domain)
 	proof, _ := Open(&domain, poly, *point, &srs.CommitKey)
@@ -171,7 +171,7 @@ func randValidOpeningProof(t *testing.T, domain Domain, srs SRS) (OpeningProof, 
 func randPoly(t *testing.T, domain Domain) []fr.Element {
 	var poly []fr.Element
 	for i := 0; i < int(domain.Cardinality); i++ {
-		var randFr = randomScalarNotInDomain(t, domain)
+		randFr := randomScalarNotInDomain(t, domain)
 		poly = append(poly, randFr)
 	}
 	return poly

--- a/internal/kzg/kzg_verify.go
+++ b/internal/kzg/kzg_verify.go
@@ -208,7 +208,7 @@ func BatchVerifyMultiPoints(commitments []Commitment, proofs []OpeningProof, ope
 // - Between evaluations and factors; This is a dot product
 //
 // Modified slightly from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/kzg/kzg.go#L464)
-func fold(commitments []Commitment, evaluations []fr.Element, factors []fr.Element) (Commitment, fr.Element, error) {
+func fold(commitments []Commitment, evaluations, factors []fr.Element) (Commitment, fr.Element, error) {
 	// Length inconsistency between commitments and evaluations should have been done before calling this function
 	batchSize := len(commitments)
 

--- a/internal/kzg/srs_test.go
+++ b/internal/kzg/srs_test.go
@@ -47,5 +47,4 @@ func TestCommitRegression(t *testing.T) {
 	if got_commitment != expected_commitment {
 		t.Fatalf("code has changed or introduced a bug, since this test vector's value has changed")
 	}
-
 }

--- a/internal/multiexp/multiexp_test.go
+++ b/internal/multiexp/multiexp_test.go
@@ -31,6 +31,7 @@ func TestMultiExpSmoke(t *testing.T) {
 		t.Error("inconsistent multi-exp result")
 	}
 }
+
 func TestMultiExpMismatchedLength(t *testing.T) {
 	var base fr.Element
 	base.SetInt64(123)
@@ -51,10 +52,9 @@ func TestMultiExpMismatchedLength(t *testing.T) {
 	if err == nil {
 		t.Error("number of points != number of scalars. Should produce an error")
 	}
-
 }
-func TestMultiExpZeroLength(t *testing.T) {
 
+func TestMultiExpZeroLength(t *testing.T) {
 	result, err := MultiExp([]fr.Element{}, []bls12381.G1Affine{})
 	if err != nil {
 		t.Error("number of points != number of scalars. Should produce an error")
@@ -64,6 +64,7 @@ func TestMultiExpZeroLength(t *testing.T) {
 		t.Error("result should be identity when instance size is 0")
 	}
 }
+
 func TestIsIdentitySmoke(t *testing.T) {
 	// Check that the identity point is encoded as (0,0) which is the point at infinity
 	// Really this is an abstraction leak from gnark

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -14,7 +14,7 @@ func TestSliceReverse(t *testing.T) {
 		slice, reversedSlice []byte
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{[]byte{1, 2, 3, 4}, []byte{4, 3, 2, 1}},
 		{[]byte{1, 2, 3, 4, 5}, []byte{5, 4, 3, 2, 1}},
 		{[]byte{1}, []byte{1}},
@@ -33,7 +33,8 @@ func TestSliceReverse(t *testing.T) {
 }
 
 func TestArrReverseSmoke(t *testing.T) {
-	arr := [32]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+	arr := [32]uint8{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 		11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 		21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
 		31, 32,
@@ -119,9 +120,8 @@ func TestComputePowersSmoke(t *testing.T) {
 }
 
 func TestCanonicalEncoding(t *testing.T) {
-
 	x := randReducedBigInt()
-	var xPlusModulus = addModP(x)
+	xPlusModulus := addModP(x)
 
 	unreducedBytes := xPlusModulus.Bytes()
 
@@ -153,7 +153,6 @@ func TestCanonicalEncoding(t *testing.T) {
 	if !gotReduced.Equal(&reduced) {
 		t.Error("incorrect field element interpretation from unreduced byte representation")
 	}
-
 }
 
 // Adds the modulus to the big integer

--- a/serialization/serialization.go
+++ b/serialization/serialization.go
@@ -32,9 +32,11 @@ const CompressedG2Size = 96
 // element corresponding to the order of the G1 group.
 const SerializedScalarSize = 32
 
-type Scalar [SerializedScalarSize]byte
-type G1Point = [CompressedG1Size]byte
-type G2Point = [CompressedG2Size]byte
+type (
+	Scalar  [SerializedScalarSize]byte
+	G1Point = [CompressedG1Size]byte
+	G2Point = [CompressedG2Size]byte
+)
 
 // A blob is a flattened representation for a serialized polynomial
 type Blob [ScalarsPerBlob * SerializedScalarSize]byte
@@ -80,6 +82,7 @@ func DeserializeG1Points(serCommitments []KZGCommitment) ([]bls12381.G1Affine, e
 
 	return commitments, nil
 }
+
 func SerializeG1Points(commitments []bls12381.G1Affine) []KZGCommitment {
 	serCommitments := make([]KZGCommitment, len(commitments))
 	for i := 0; i < len(commitments); i++ {
@@ -193,6 +196,7 @@ func SerializePoly(poly kzg.Polynomial) Blob {
 func SerializeG2Point(point bls12381.G2Affine) G2Point {
 	return point.Bytes()
 }
+
 func DeserializeG2Point(serPoint G2Point) (bls12381.G2Affine, error) {
 	var point bls12381.G2Affine
 

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -22,7 +22,6 @@ func TestG1RoundTripSmoke(t *testing.T) {
 }
 
 func TestSerializePolyNotZero(t *testing.T) {
-
 	// Check that blobs are not all zeroes
 	// This would indicate that serialization
 	// did not do anything.
@@ -37,7 +36,6 @@ func TestSerializePolyNotZero(t *testing.T) {
 }
 
 func TestSerializePolyRoundTrip(t *testing.T) {
-
 	expectedPolyA := randPoly4096()
 	expectedPolyB := randPoly4096()
 
@@ -59,7 +57,7 @@ func TestSerializePolyRoundTrip(t *testing.T) {
 }
 
 // Check element-wise that each evaluation in the polynomial is the same
-func assertPolyEqual(t *testing.T, lhs kzg.Polynomial, rhs kzg.Polynomial) {
+func assertPolyEqual(t *testing.T, lhs, rhs kzg.Polynomial) {
 	polyLen := assertPolySameLength(t, lhs, rhs)
 
 	for i := 0; i < polyLen; i++ {
@@ -71,7 +69,7 @@ func assertPolyEqual(t *testing.T, lhs kzg.Polynomial, rhs kzg.Polynomial) {
 
 // Assert that two polynomials are different -- differ at atleast one
 // evaluation
-func assertPolyNotEqual(t *testing.T, lhs kzg.Polynomial, rhs kzg.Polynomial) {
+func assertPolyNotEqual(t *testing.T, lhs, rhs kzg.Polynomial) {
 	polyLen := assertPolySameLength(t, lhs, rhs)
 
 	// element at index `i` in polyPredicate stores whether the
@@ -98,7 +96,8 @@ func assertPolyNotEqual(t *testing.T, lhs kzg.Polynomial, rhs kzg.Polynomial) {
 	// If we get here then the polynomials were the same at every index
 	t.Error("polynomials had the same evaluations and are therefore the same")
 }
-func assertPolySameLength(t *testing.T, lhs kzg.Polynomial, rhs kzg.Polynomial) int {
+
+func assertPolySameLength(t *testing.T, lhs, rhs kzg.Polynomial) int {
 	// Assert that the polynomials are the same size
 	lenLhs := len(lhs)
 	lenRhs := len(rhs)


### PR DESCRIPTION
This the codebase according to [`gofumpt -extra`](https://github.com/mvdan/gofumpt).

Eventually, I'll add [`golangci-lint`](https://golangci-lint.run) to enforce this.