### PR TITLE
Rename global constant to match spec

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,12 +18,17 @@ type Context struct {
 	openKey   *kzg.OpeningKey
 }
 
-// MODULUS represents the order of the bls12-381 scalar field as a 32 byte array.
-var MODULUS = [32]byte{115, 237, 167, 83, 41, 157, 125, 72, 51, 57, 216, 8, 9, 161, 216, 5, 83, 189, 164, 2, 255, 254, 91, 254, 255, 255, 255, 255, 0, 0, 0, 1}
+// BlsModulus is the bytes representation of the bls12-381 scalar field modulus:
+//   52435875175126190479447740508185965837690552500527637822603658699938581184513
+var BlsModulus = [32]byte{
+	0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48,
+	0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+	0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe,
+	0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01}
 
-// ZERO_POINT represents the identity point in G1.
-// This can be used as the Zero/Identity point for KZGProof or KZGCommitment.
-var ZERO_POINT = [48]byte{192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+// PointAtInfinity represents the serialized form of the point at infinity
+// on the G1 group. This is defined as Bytes48(b'\xc0' + b'\x00' * 47).
+var PointAtInfinity = [48]byte{0xc0}
 
 // NewContext4096Insecure1337 creates a new context object which will hold all of the state needed
 // for one to use the EIP-4844 methods.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"bytes"
 	"math/big"
 	"testing"
 
@@ -9,22 +8,18 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-proto-danksharding-crypto/api"
 	"github.com/crate-crypto/go-proto-danksharding-crypto/serialization"
+	"github.com/stretchr/testify/require"
 )
 
-func TestModulus(t *testing.T) {
+func TestBlsModulus(t *testing.T) {
 	expectedModulus := fr.Modulus()
-	if !bytes.Equal(expectedModulus.Bytes(), api.MODULUS[:]) {
-		t.Error("expected modulus does not match the defined constant")
-	}
+	require.Equal(t, expectedModulus.Bytes(), api.BlsModulus[:])
 }
 
-func TestZeroPoint(t *testing.T) {
-	var zeroPoint bls12381.G1Affine
-	expectedZeroPoint := serialization.SerializeG1Point(zeroPoint)
-
-	if !bytes.Equal(expectedZeroPoint[:], api.ZERO_POINT[:]) {
-		t.Error("expected zero point does not match the defined constant")
-	}
+func TestPointAtInfinity(t *testing.T) {
+	var pointAtInfinity bls12381.G1Affine
+	expectedPointAtInfinity := serialization.SerializeG1Point(pointAtInfinity)
+	require.Equal(t, expectedPointAtInfinity, api.PointAtInfinity)
 }
 
 func TestNonCanonicalSmoke(t *testing.T) {


### PR DESCRIPTION
* Rename variables to better match the [spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants).
  * I think ZeroPoint is a valid name, but just going with the spec here.
  * Also, the linters complained about these being ALL_UPPERCASE.
* Update comments a bit.
* Change from array of decimal integers to hexadecimal.
  * Also, wrap (4 lines of 8 bytes).
* Update tests to be a little cleaner.