### PR TITLE
Fix gosec finding

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - errorlint
     - gocognit
     - goerr113
-    - gosec
     - makezero
     - nilerr
     - nlreturn
@@ -65,6 +64,9 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+  gosec:
+    excludes:
+     - G404 # Insecure random number source (rand)
 
 output:
   print-issued-lines: true

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -113,7 +113,8 @@ func TestComputePowersSmoke(t *testing.T) {
 		var expected fr.Element
 		expected.Exp(base, big.NewInt(int64(index)))
 
-		if !expected.Equal(&pow) {
+		powCopy := pow
+		if !expected.Equal(&powCopy) {
 			t.Error("incorrect exponentiation result")
 		}
 	}


### PR DESCRIPTION
There was one real finding:

```
internal/utils/utils_test.go:116:22: G601: Implicit memory aliasing in for loop. (gosec)
                if !expected.Equal(&pow) {
```

This PR fixes it.

As for the other one, we're fine with using `math/rand` so I disabled that check.