### PR TITLE
Fix some makezero findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - gocognit
     - goerr113
     - gosec
-    - makezero
     - nilerr
     - nlreturn
     - nonamedreturns


### PR DESCRIPTION
The `makezero` correctly identified some problems:

```
internal/kzg/kzg_test.go:38:17: append to slice `commitments` with non-zero initialized length (makezero)
                commitments = append(commitments, comm)
                              ^
internal/kzg/kzg_test.go:39:12: append to slice `proofs` with non-zero initialized length (makezero)
                proofs = append(proofs, proof)
                         ^
internal/kzg/kzg_test.go:47:16: append to slice `commitments` with non-zero initialized length (makezero)
        commitments = append(commitments, bls12381.G1Affine{})
                      ^
internal/kzg/kzg_test.go:48:11: append to slice `proofs` with non-zero initialized length (makezero)
        proofs = append(proofs, proof)
```

This test was appending commitments/proofs to an array that was already initialized. 