### PR TITLE
Fix revive/nosnakecase findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,8 +28,6 @@ linters:
     - nilerr
     - nlreturn
     - nonamedreturns
-    - nosnakecase
-    - revive
     - stylecheck
     - tagliatelle
     - thelper
@@ -54,6 +52,7 @@ linters:
     - ifshort
     - interfacer
     - maligned
+    - nosnakecase
     - scopelint
     - varcheck
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,10 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+  revive:
+    rules:
+      - name: var-naming
+        disabled: true
 
 output:
   print-issued-lines: true

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -117,8 +117,8 @@ func createScalarNonCanonical(serScalar serialization.Scalar) serialization.Scal
 func addModP(x big.Int) big.Int {
 	modulus := fr.Modulus()
 
-	var x_plus_modulus big.Int
-	x_plus_modulus.Add(&x, modulus)
+	var xPlusModulus big.Int
+	xPlusModulus.Add(&x, modulus)
 
-	return x_plus_modulus
+	return xPlusModulus
 }

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -36,7 +36,7 @@ func GetRandBlob(seed int64) serialization.Blob {
 
 var ctxG *api.Context
 
-func BenchmarkSetup(b *testing.B) {
+func BenchmarkSetup(_ *testing.B) {
 	ctx, err := api.NewContext4096Insecure1337()
 	if err != nil {
 		panic(err)

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -26,7 +26,6 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 	commitment, err := ctx.BlobToKZGCommitment(blob)
 	require.NoError(t, err)
 	inputPoint := GetRandFieldElement(123)
-	require.NoError(t, err)
 	proof, claimedValue, err := ctx.ComputeKZGProof(blob, inputPoint)
 	require.NoError(t, err)
 	err = ctx.VerifyKZGProof(commitment, inputPoint, claimedValue, proof)

--- a/api/examples_test.go
+++ b/api/examples_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/crate-crypto/go-proto-danksharding-crypto/api"
 	"github.com/crate-crypto/go-proto-danksharding-crypto/serialization"
+	"github.com/stretchr/testify/require"
 )
 
 // Globally initialize a ctx for tests.
@@ -12,61 +13,43 @@ var ctx, _ = api.NewContext4096Insecure1337()
 
 func TestBlobProveVerifyRandomPointIntegration(t *testing.T) {
 	blob := GetRandBlob(123)
-
 	commitment, err := ctx.BlobToKZGCommitment(blob)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	proof, err := ctx.ComputeBlobKZGProof(blob, commitment)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = ctx.VerifyBlobKZGProof(blob, commitment, proof)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 	blob := GetRandBlob(123)
-
 	commitment, err := ctx.BlobToKZGCommitment(blob)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	inputPoint := GetRandFieldElement(123)
+	require.NoError(t, err)
 	proof, claimedValue, err := ctx.ComputeKZGProof(blob, inputPoint)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = ctx.VerifyKZGProof(commitment, inputPoint, claimedValue, proof)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 	batchSize := 5
-
 	blobs := make([]serialization.Blob, batchSize)
 	commitments := make([]serialization.KZGCommitment, batchSize)
 	proofs := make([]serialization.KZGProof, batchSize)
 
 	for i := 0; i < batchSize; i++ {
-		blobs[i] = GetRandBlob(int64(i))
-		commitment_i, err := ctx.BlobToKZGCommitment(blobs[i])
-		if err != nil {
-			t.Error(err)
-		}
-		commitments[i] = commitment_i
-		proof_i, err := ctx.ComputeBlobKZGProof(blobs[i], commitments[i])
-		if err != nil {
-			t.Error(err)
-		}
-		proofs[i] = proof_i
+		blob := GetRandBlob(int64(i))
+		commitment, err := ctx.BlobToKZGCommitment(blob)
+		require.NoError(t, err)
+		proof, err := ctx.ComputeBlobKZGProof(blob, commitment)
+		require.NoError(t, err)
+
+		blobs[i] = blob
+		commitments[i] = commitment
+		proofs[i] = proof
 	}
 	err := ctx.VerifyBlobKZGProofBatch(blobs, commitments, proofs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }

--- a/api/trusted_setup.go
+++ b/api/trusted_setup.go
@@ -169,12 +169,12 @@ func parseG1PointsNoSubgroupCheck(hexStrings []string) ([]bls12381.G1Affine, err
 	var wg sync.WaitGroup
 	wg.Add(numG1)
 	for i := 0; i < numG1; i++ {
-		go func(_i int) {
-			g1Point, err := parseG1PointNoSubgroupCheck(hexStrings[_i])
+		go func(j int) {
+			g1Point, err := parseG1PointNoSubgroupCheck(hexStrings[j])
 			if err != nil {
 				panic(err)
 			}
-			g1Points[_i] = g1Point
+			g1Points[j] = g1Point
 			wg.Done()
 		}(i)
 	}

--- a/api/verify.go
+++ b/api/verify.go
@@ -169,9 +169,5 @@ func (c *Context) VerifyBlobKZGProofBatchPar(blobs []serialization.Blob, polynom
 	}
 
 	// 3. Wait for all go routines to complete and check if any returned an error
-	if err := errG.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return errG.Wait()
 }

--- a/internal/kzg/domain_test.go
+++ b/internal/kzg/domain_test.go
@@ -89,7 +89,7 @@ func bitReversalPermutation(l []fr.Element) []fr.Element {
 
 func TestEvalPolynomialSmoke(t *testing.T) {
 	// The polynomial in question is: f(x) =  x^2 + x
-	f_x := func(x fr.Element) fr.Element {
+	f := func(x fr.Element) fr.Element {
 		var tmp fr.Element
 		tmp.Square(&x)
 		tmp.Add(&tmp, &x)
@@ -106,7 +106,7 @@ func TestEvalPolynomialSmoke(t *testing.T) {
 	lagrangePoly := make([]fr.Element, domain.Cardinality)
 	for i := 0; i < int(domain.Cardinality); i++ {
 		x := domain.Roots[i]
-		lagrangePoly[i] = f_x(x)
+		lagrangePoly[i] = f(x)
 	}
 
 	// Evaluate the lagrange polynomial at all points in the domain
@@ -145,7 +145,7 @@ func TestEvalPolynomialSmoke(t *testing.T) {
 
 		// Now we evaluate the polynomial in monomial form
 		// on the point outside of the domain
-		expectedPoint := f_x(*inputPoint)
+		expectedPoint := f(*inputPoint)
 
 		if !expectedPoint.Equal(gotOutputPoint) {
 			t.Fatalf("unexpected evaluation of polynomial at point %v", inputPoint.Bytes())

--- a/internal/kzg/fft_test.go
+++ b/internal/kzg/fft_test.go
@@ -9,7 +9,7 @@ func TestSRSConversion(t *testing.T) {
 	n := uint64(4096)
 	domain := NewDomain(n)
 	secret := big.NewInt(100)
-	srsMonomial, err := newMonomialSRSInsecure_uint64(n, secret)
+	srsMonomial, err := monomialSRSInsecureUint64(n, secret)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/kzg/fft_test.go
+++ b/internal/kzg/fft_test.go
@@ -9,7 +9,7 @@ func TestSRSConversion(t *testing.T) {
 	n := uint64(4096)
 	domain := NewDomain(n)
 	secret := big.NewInt(100)
-	srsMonomial, err := monomialSRSInsecureUint64(n, secret)
+	srsMonomial, err := newMonomialSRSInsecureUint64(n, secret)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -139,32 +139,32 @@ func (domain *Domain) computeQuotientPolyOnDomain(f Polynomial, index uint64) ([
 			continue
 		}
 
-		// Compute qJ = fJ / w^j - w^m for j != m.
+		// Compute q_j = f_j / w^j - w^m for j != m.
 		// This is exactly the same as in the computeQuotientPolyOutsideDomain - case.
 		//
-		// Note: fJ is the numerator of the quotient polynomial ie fJ = f[j] - f(z)
+		// Note: f_j is the numerator of the quotient polynomial ie f_j = f[j] - f(z)
 		//
 		//
-		var qJ fr.Element
-		qJ.Sub(&f[j], &fz)
-		qJ.Mul(&qJ, &invRootsMinusZ[j])
-		quotientPoly[j] = qJ
+		var q_j fr.Element
+		q_j.Sub(&f[j], &fz)
+		q_j.Mul(&q_j, &invRootsMinusZ[j])
+		quotientPoly[j] = q_j
 
 		// Compute the contribution to q_m coming from the j'th term of the input.
 		// This term is given by
-		// qMJ = (fJ / w^m - w^j) * (w^j/w^m) , where w^m = z
-		//		 = - qJ * w^{j-m}
+		// q_m_j = (f_j / w^m - w^j) * (w^j/w^m) , where w^m = z
+		//		 = - q_j * w^{j-m}
 		//
 		// We _could_ find 1 / w^{j-m} via a lookup table
 		// but we want to avoid lookup tables because
 		// the roots are bit-reversed which can make the
 		// code less readable.
-		var qMJ fr.Element
-		qMJ.Neg(&qJ)
-		qMJ.Mul(&qMJ, &domain.Roots[j])
-		qMJ.Mul(&qMJ, &invZ)
+		var q_m_j fr.Element
+		q_m_j.Neg(&q_j)
+		q_m_j.Mul(&q_m_j, &domain.Roots[j])
+		q_m_j.Mul(&q_m_j, &invZ)
 
-		quotientPoly[index].Add(&quotientPoly[index], &qMJ)
+		quotientPoly[index].Add(&quotientPoly[index], &q_m_j)
 	}
 
 	return quotientPoly, nil

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -139,32 +139,32 @@ func (domain *Domain) computeQuotientPolyOnDomain(f Polynomial, index uint64) ([
 			continue
 		}
 
-		// Compute q_j = f_j / w^j - w^m for j != m.
+		// Compute qJ = fJ / w^j - w^m for j != m.
 		// This is exactly the same as in the computeQuotientPolyOutsideDomain - case.
 		//
-		// Note: f_j is the numerator of the quotient polynomial ie f_j = f[j] - f(z)
+		// Note: fJ is the numerator of the quotient polynomial ie fJ = f[j] - f(z)
 		//
 		//
-		var q_j fr.Element
-		q_j.Sub(&f[j], &fz)
-		q_j.Mul(&q_j, &invRootsMinusZ[j])
-		quotientPoly[j] = q_j
+		var qJ fr.Element
+		qJ.Sub(&f[j], &fz)
+		qJ.Mul(&qJ, &invRootsMinusZ[j])
+		quotientPoly[j] = qJ
 
 		// Compute the contribution to q_m coming from the j'th term of the input.
 		// This term is given by
-		// q_m_j = (f_j / w^m - w^j) * (w^j/w^m) , where w^m = z
-		//		 = - q_j * w^{j-m}
+		// qMJ = (fJ / w^m - w^j) * (w^j/w^m) , where w^m = z
+		//		 = - qJ * w^{j-m}
 		//
 		// We _could_ find 1 / w^{j-m} via a lookup table
 		// but we want to avoid lookup tables because
 		// the roots are bit-reversed which can make the
 		// code less readable.
-		var q_m_j fr.Element
-		q_m_j.Neg(&q_j)
-		q_m_j.Mul(&q_m_j, &domain.Roots[j])
-		q_m_j.Mul(&q_m_j, &invZ)
+		var qMJ fr.Element
+		qMJ.Neg(&qJ)
+		qMJ.Mul(&qMJ, &domain.Roots[j])
+		qMJ.Mul(&qMJ, &invZ)
 
-		quotientPoly[index].Add(&quotientPoly[index], &q_m_j)
+		quotientPoly[index].Add(&quotientPoly[index], &qMJ)
 	}
 
 	return quotientPoly, nil

--- a/internal/kzg/kzg_test.go
+++ b/internal/kzg/kzg_test.go
@@ -127,7 +127,7 @@ func computeQuotientPolySlow(domain Domain, f Polynomial, z fr.Element) ([]fr.El
 		a := polyShifted[i]
 		b := denominatorPoly[i]
 		if b.IsZero() {
-			quotient[i] = compute_quotient_eval_within_domain(domain, domain.Roots[i], f, *y)
+			quotient[i] = computeQuotientEvalWithinDomain(domain, domain.Roots[i], f, *y)
 		} else {
 			quotient[i].Div(&a, &b)
 		}
@@ -136,19 +136,19 @@ func computeQuotientPolySlow(domain Domain, f Polynomial, z fr.Element) ([]fr.El
 	return quotient, nil
 }
 
-func compute_quotient_eval_within_domain(domain Domain, z fr.Element, polynomial []fr.Element, y fr.Element) fr.Element {
+func computeQuotientEvalWithinDomain(domain Domain, z fr.Element, polynomial []fr.Element, y fr.Element) fr.Element {
 	var result fr.Element
 	for i := 0; i < int(domain.Cardinality); i++ {
-		omega_i := domain.Roots[i]
-		if omega_i.Equal(&z) {
+		omega := domain.Roots[i]
+		if omega.Equal(&z) {
 			continue
 		}
-		var f_i fr.Element
-		f_i.Sub(&polynomial[i], &y)
+		var f fr.Element
+		f.Sub(&polynomial[i], &y)
 		var numerator fr.Element
-		numerator.Mul(&f_i, &omega_i)
+		numerator.Mul(&f, &omega)
 		var denominator fr.Element
-		denominator.Sub(&z, &omega_i)
+		denominator.Sub(&z, &omega)
 		denominator.Mul(&denominator, &z)
 
 		var tmp fr.Element

--- a/internal/kzg/srs_insecure.go
+++ b/internal/kzg/srs_insecure.go
@@ -32,7 +32,7 @@ func newMonomialSRSInsecure(domain Domain, bAlpha *big.Int) (*SRS, error) {
 //
 // This method should not be used in production because as the secret is supplied as input.
 func newSRSInsecure(domain Domain, bAlpha *big.Int, convertToLagrange bool) (*SRS, error) {
-	srs, err := monomialSRSInsecureUint64(domain.Cardinality, bAlpha)
+	srs, err := newMonomialSRSInsecureUint64(domain.Cardinality, bAlpha)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func newSRSInsecure(domain Domain, bAlpha *big.Int, convertToLagrange bool) (*SR
 	return srs, nil
 }
 
-// monomialSRSInsecureUint64 creates a new SRS object with the secret `bAlpha` in monomial basis.
+// newMonomialSRSInsecureUint64 creates a new SRS object with the secret `bAlpha` in monomial basis.
 //
 // Note that the function name ends with Uint64, because we provide the size argument as a
 // uint64 rather than a Domain. A newMonomialSRSInsecure functions taking a Domain as input
@@ -55,7 +55,7 @@ func newSRSInsecure(domain Domain, bAlpha *big.Int, convertToLagrange bool) (*SR
 // This method should not be used in production because as the secret is supplied as input.
 
 // Copied from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/kzg/kzg.go#L65)
-func monomialSRSInsecureUint64(size uint64, bAlpha *big.Int) (*SRS, error) {
+func newMonomialSRSInsecureUint64(size uint64, bAlpha *big.Int) (*SRS, error) {
 	if size < 2 {
 		return nil, ErrMinSRSSize
 	}

--- a/internal/kzg/srs_insecure.go
+++ b/internal/kzg/srs_insecure.go
@@ -32,7 +32,7 @@ func newMonomialSRSInsecure(domain Domain, bAlpha *big.Int) (*SRS, error) {
 //
 // This method should not be used in production because as the secret is supplied as input.
 func newSRSInsecure(domain Domain, bAlpha *big.Int, convertToLagrange bool) (*SRS, error) {
-	srs, err := newMonomialSRSInsecure_uint64(domain.Cardinality, bAlpha)
+	srs, err := monomialSRSInsecureUint64(domain.Cardinality, bAlpha)
 	if err != nil {
 		return nil, err
 	}
@@ -46,16 +46,16 @@ func newSRSInsecure(domain Domain, bAlpha *big.Int, convertToLagrange bool) (*SR
 	return srs, nil
 }
 
-// newMonomialSRSInsecure_uint64 creates a new SRS object with the secret `bAlpha` in monomial basis.
+// monomialSRSInsecureUint64 creates a new SRS object with the secret `bAlpha` in monomial basis.
 //
-// Note that the function is named _size, because we provide the size argument as a
+// Note that the function name ends with Uint64, because we provide the size argument as a
 // uint64 rather than a Domain. A newMonomialSRSInsecure functions taking a Domain as input
 // to match the other functions is defined in the testing code.
 //
 // This method should not be used in production because as the secret is supplied as input.
 
 // Copied from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/kzg/kzg.go#L65)
-func newMonomialSRSInsecure_uint64(size uint64, bAlpha *big.Int) (*SRS, error) {
+func monomialSRSInsecureUint64(size uint64, bAlpha *big.Int) (*SRS, error) {
 	if size < 2 {
 		return nil, ErrMinSRSSize
 	}

--- a/internal/kzg/srs_test.go
+++ b/internal/kzg/srs_test.go
@@ -6,45 +6,40 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLagrangeSRSSmoke(t *testing.T) {
 	size := uint64(4)
 	domain := NewDomain(size)
-	srs_lagrange, _ := newLagrangeSRSInsecure(*domain, big.NewInt(100))
-	srs_monomial, _ := newMonomialSRSInsecure(*domain, big.NewInt(100))
+	srsLagrange, _ := newLagrangeSRSInsecure(*domain, big.NewInt(100))
+	srsMonomial, _ := newMonomialSRSInsecure(*domain, big.NewInt(100))
 
 	// 1 + x + x^2
-	poly_monomial := []fr.Element{fr.One(), fr.One(), fr.One()}
-	f_x := func(x fr.Element) fr.Element {
+	polyMonomial := []fr.Element{fr.One(), fr.One(), fr.One()}
+	f := func(x fr.Element) fr.Element {
 		one := fr.One()
 		var tmp fr.Element
 		tmp.Square(&x)
 		tmp.Add(&tmp, &x)
 		tmp.Add(&tmp, &one)
-
 		return tmp
 	}
-	poly_lagrange := []fr.Element{f_x(domain.Roots[0]), f_x(domain.Roots[1]), f_x(domain.Roots[2]), f_x(domain.Roots[3])}
+	polyLagrange := []fr.Element{f(domain.Roots[0]), f(domain.Roots[1]), f(domain.Roots[2]), f(domain.Roots[3])}
 
-	c_l, _ := Commit(poly_lagrange, &srs_lagrange.CommitKey)
-	c_m, _ := Commit(poly_monomial, &srs_monomial.CommitKey)
-	if !c_l.Equal(c_m) {
-		t.Error("commitment mismatch between monomial srs and lagrange srs")
-	}
+	commitmentLagrange, _ := Commit(polyLagrange, &srsLagrange.CommitKey)
+	commitmentMonomial, _ := Commit(polyMonomial, &srsMonomial.CommitKey)
+	require.Equal(t, commitmentLagrange, commitmentMonomial)
 }
 
 func TestCommitRegression(t *testing.T) {
 	domain := NewDomain(4)
-	srs_lagrange, _ := newLagrangeSRSInsecure(*domain, big.NewInt(100))
+	srsLagrange, _ := newLagrangeSRSInsecure(*domain, big.NewInt(100))
 
 	poly := []fr.Element{fr.NewElement(12345), fr.NewElement(123456), fr.NewElement(1234567), fr.NewElement(12345678)}
-	c_l, _ := Commit(poly, &srs_lagrange.CommitKey)
-	c_l_bytes := c_l.Bytes()
-	got_commitment := hex.EncodeToString(c_l_bytes[:])
-	expected_commitment := "85bdf872da5b8561d23055d32db3fc86c672b0be7543b8c1e48634af07231bf7ab6385b765750921017cbcdbcd14f8e0"
-
-	if got_commitment != expected_commitment {
-		t.Fatalf("code has changed or introduced a bug, since this test vector's value has changed")
-	}
+	cLagrange, _ := Commit(poly, &srsLagrange.CommitKey)
+	cLagrangeBytes := cLagrange.Bytes()
+	gotCommitment := hex.EncodeToString(cLagrangeBytes[:])
+	expectedCommitment := "85bdf872da5b8561d23055d32db3fc86c672b0be7543b8c1e48634af07231bf7ab6385b765750921017cbcdbcd14f8e0"
+	require.Equal(t, expectedCommitment, gotCommitment)
 }

--- a/internal/multiexp/multiexp_test.go
+++ b/internal/multiexp/multiexp_test.go
@@ -14,10 +14,10 @@ func TestMultiExpSmoke(t *testing.T) {
 	var base fr.Element
 	base.SetInt64(1234567)
 
-	instance_size := uint(256)
+	instanceSize := uint(256)
 
-	powers := utils.ComputePowers(base, instance_size)
-	points := genG1Points(instance_size)
+	powers := utils.ComputePowers(base, instanceSize)
+	points := genG1Points(instanceSize)
 
 	got, err := MultiExp(powers, points)
 	if err != nil {
@@ -36,18 +36,18 @@ func TestMultiExpMismatchedLength(t *testing.T) {
 	var base fr.Element
 	base.SetInt64(123)
 
-	instance_size := uint(16)
+	instanceSize := uint(16)
 
-	powers := utils.ComputePowers(base, instance_size)
-	points := genG1Points(instance_size + 1)
+	powers := utils.ComputePowers(base, instanceSize)
+	points := genG1Points(instanceSize + 1)
 
 	_, err := MultiExp(powers, points)
 	if err == nil {
 		t.Error("number of points != number of scalars. Should produce an error")
 	}
 
-	powers = utils.ComputePowers(base, instance_size+1)
-	points = genG1Points(instance_size)
+	powers = utils.ComputePowers(base, instanceSize+1)
+	points = genG1Points(instanceSize)
 	_, err = MultiExp(powers, points)
 	if err == nil {
 		t.Error("number of points != number of scalars. Should produce an error")
@@ -109,14 +109,14 @@ func genG1Points(n uint) []bls12381.G1Affine {
 		return []bls12381.G1Affine{}
 	}
 
-	_, _, g1_gen, _ := bls12381.Generators()
+	_, _, g1Gen, _ := bls12381.Generators()
 
 	var points []bls12381.G1Affine
-	points = append(points, g1_gen)
+	points = append(points, g1Gen)
 
 	for i := uint(1); i < n; i++ {
 		var tmp bls12381.G1Affine
-		tmp.Add(&g1_gen, &points[i-1])
+		tmp.Add(&g1Gen, &points[i-1])
 		points = append(points, tmp)
 
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -162,10 +162,10 @@ func TestCanonicalEncoding(t *testing.T) {
 func addModP(x big.Int) big.Int {
 	modulus := fr.Modulus()
 
-	var x_plus_modulus big.Int
-	x_plus_modulus.Add(&x, modulus)
+	var xPlusModulus big.Int
+	xPlusModulus.Add(&x, modulus)
 
-	return x_plus_modulus
+	return xPlusModulus
 }
 
 func randReducedBigInt() big.Int {

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -7,6 +7,7 @@ import (
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-proto-danksharding-crypto/internal/kzg"
+	"github.com/stretchr/testify/require"
 )
 
 func TestG1RoundTripSmoke(t *testing.T) {
@@ -99,12 +100,8 @@ func assertPolyNotEqual(t *testing.T, lhs, rhs kzg.Polynomial) {
 
 func assertPolySameLength(t *testing.T, lhs, rhs kzg.Polynomial) int {
 	// Assert that the polynomials are the same size
-	lenLhs := len(lhs)
-	lenRhs := len(rhs)
-	if lenLhs != lenRhs {
-		t.Errorf("polynomials cannot be equal as they are not the same size, lhs : %d, rhs : %d", lenLhs, lenRhs)
-	}
-	return lenLhs
+	require.Equal(t, len(lhs), len(rhs))
+	return len(lhs)
 }
 
 func randPoly4096() kzg.Polynomial {


### PR DESCRIPTION
This PR changes a bunch of variable names (ugh) and uses more testify.

Also, `nosnakecase` is now deprecated and all of the findings are found by `revive`.