### PR TITLE
Ignore IntelliJ .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_STORE
+.idea


### PR DESCRIPTION
Add `.idea` to the ignore list. This is the directory associated with IntelliJ IDEA.