### PR TITLE
Clean the serialization file

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -48,7 +48,7 @@ func (c *Context) ComputeBlobKZGProof(blob Blob, blobCommitment KZGCommitment) (
 	// Deserialize commitment
 	//
 	// We only do this to check if it is in the correct subgroup
-	_, err = DeserializeG1Point(G1Point(blobCommitment))
+	_, err = DeserializeKZGCommitment(blobCommitment)
 	if err != nil {
 		return KZGProof{}, err
 	}

--- a/serialization.go
+++ b/serialization.go
@@ -1,38 +1,38 @@
 package gokzg4844
 
 import (
-	"errors"
-
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-kzg-4844/internal/kzg"
 	"github.com/crate-crypto/go-kzg-4844/internal/utils"
 )
 
-// ScalarsPerBlob is the number of serialized scalars in a blob.
-//
-// It matches [FIELD_ELEMENTS_PER_BLOB] in the spec.
-//
-// Note: These scalars are not guaranteed to be valid (a value less than [BLS_MODULUS]). If any of the scalars in a blob
-// are invalid (non-canonical), an error will be returned on de
-//
-// [BLS_MODULUS]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#constants
-// [FIELD_ELEMENTS_PER_BLOB]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#blob
-const ScalarsPerBlob = 4096
+const (
+	// CompressedG1Size is the number of bytes needed to represent a group element in G1 when compressed.
+	CompressedG1Size = 48
 
-// CompressedG1Size is the number of bytes needed to represent a group element in G1 when compressed.
-const CompressedG1Size = 48
+	// CompressedG2Size is the number of bytes needed to represent a group element in G2 when compressed.
+	CompressedG2Size = 96
 
-// CompressedG2Size is the number of bytes needed to represent a group element in G2 when compressed.
-const CompressedG2Size = 96
+	// SerializedScalarSize is the number of bytes needed to represent a field element corresponding to the order of the
+	// G1 group.
+	//
+	// It matches [BYTES_PER_FIELD_ELEMENT] in the spec.
+	//
+	// [BYTES_PER_FIELD_ELEMENT]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#constants
+	SerializedScalarSize = 32
 
-// SerializedScalarSize is the number of bytes needed to represent a field element corresponding to the order of the G1
-// group.
-//
-// It matches [BYTES_PER_FIELD_ELEMENT] in the spec.
-//
-// [BYTES_PER_FIELD_ELEMENT]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#constants
-const SerializedScalarSize = 32
+	// ScalarsPerBlob is the number of serialized scalars in a blob.
+	//
+	// It matches [FIELD_ELEMENTS_PER_BLOB] in the spec.
+	//
+	// Note: These scalars are not guaranteed to be valid (a value less than [BLS_MODULUS]). If any of the scalars in a
+	// blob are invalid (non-canonical), an error will be returned on de
+	//
+	// [BLS_MODULUS]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#constants
+	// [FIELD_ELEMENTS_PER_BLOB]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#blob
+	ScalarsPerBlob = 4096
+)
 
 type (
 	// G1Point matches [G1Point] in the spec.
@@ -49,77 +49,77 @@ type (
 	//
 	// [BLSFieldElement]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
 	Scalar [SerializedScalarSize]byte
+
+	// Blob is a flattened representation of a serialized polynomial.
+	//
+	// It matches [Blob] in the spec.
+	//
+	// [Blob]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
+	Blob [ScalarsPerBlob * SerializedScalarSize]byte
+
+	// KZGProof is a serialized commitment to the quotient polynomial.
+	//
+	// It matches [KZGProof] in the spec.
+	//
+	// [KZGProof]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
+	KZGProof G1Point
+
+	// KZGCommitment is a serialized commitment to a polynomial.
+	//
+	// It matches [KZGCommitment] in the spec.
+	//
+	// [KZGCommitment]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
+	KZGCommitment G1Point
 )
-
-// Blob is a flattened representation of a serialized polynomial.
-//
-// It matches [Blob] in the spec.
-//
-// [Blob]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
-type Blob [ScalarsPerBlob * SerializedScalarSize]byte
-
-// KZGProof is a serialized commitment to the quotient polynomial.
-//
-// It matches [KZGProof] in the spec.
-//
-// [KZGProof]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
-type KZGProof G1Point
-
-// KZGCommitment is a serialized commitment to a polynomial.
-//
-// It matches [KZGCommitment] in the spec.
-//
-// [KZGCommitment]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#custom-types
-type KZGCommitment G1Point
 
 // SerializeG1Point converts a [bls12381.G1Affine] to [G1Point].
 func SerializeG1Point(affine bls12381.G1Affine) G1Point {
 	return affine.Bytes()
 }
 
-// DeserializeG1Point implements [validate_kzg_g1], [bytes_to_kzg_commitment], and [bytes_to_kzg_proof]. It will return
-// an error if the point is not on the group or if the point is not in the correct subgroup.
+// deserializeG1Point converts a [G1Point] to the internal [bls12381.G1Affine] type. It will return an error if the
+// point is not on the group or if the point is not in the correct subgroup.
+//
+// It implements [validate_kzg_g1].
 //
 // [validate_kzg_g1]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#validate_kzg_g1
-// [bytes_to_kzg_commitment]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bytes_to_kzg_commitment
-// [bytes_to_kzg_proof]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bytes_to_kzg_proof
-func DeserializeG1Point(serPoint G1Point) (bls12381.G1Affine, error) {
+func deserializeG1Point(serPoint G1Point) (bls12381.G1Affine, error) {
 	var point bls12381.G1Affine
-
 	_, err := point.SetBytes(serPoint[:])
 	if err != nil {
 		return bls12381.G1Affine{}, err
 	}
-
 	return point, nil
+}
+
+// DeserializeKZGCommitment implements [bytes_to_kzg_commitment].
+//
+// [bytes_to_kzg_commitment]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bytes_to_kzg_commitment
+func DeserializeKZGCommitment(commitment KZGCommitment) (bls12381.G1Affine, error) {
+	return deserializeG1Point(G1Point(commitment))
+}
+
+// DeserializeKZGProof implements [bytes_to_kzg_proof].
+//
+// [bytes_to_kzg_proof]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bytes_to_kzg_proof
+func DeserializeKZGProof(proof KZGProof) (bls12381.G1Affine, error) {
+	return deserializeG1Point(G1Point(proof))
 }
 
 // DeserializeBlob implements [blob_to_polynomial].
 //
 // [blob_to_polynomial]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#blob_to_polynomial
 func DeserializeBlob(blob Blob) (kzg.Polynomial, error) {
-	numEvaluations := ScalarsPerBlob
-	poly := make(kzg.Polynomial, numEvaluations)
-
-	if len(blob)%SerializedScalarSize != 0 {
-		return kzg.Polynomial{}, errors.New("serialized polynomial size should be a multiple of `SERIALIZED_SCALAR_SIZE`")
-	}
-
-	for i, j := 0, 0; i < len(blob); i, j = i+SerializedScalarSize, j+1 {
-		// Move pointer to select the next serialized scalar
-		end := i + SerializedScalarSize
-
-		chunk := blob[i:end]
-		// Convert slice to array
-		serializedScalar := (*[SerializedScalarSize]byte)(chunk)
-
-		scalar, err := DeserializeScalar(*serializedScalar)
+	poly := make(kzg.Polynomial, ScalarsPerBlob)
+	for i := 0; i < ScalarsPerBlob; i++ {
+		chunk := blob[i*SerializedScalarSize : (i+1)*SerializedScalarSize]
+		serScalar := (*Scalar)(chunk)
+		scalar, err := DeserializeScalar(*serScalar)
 		if err != nil {
 			return nil, err
 		}
-		poly[j] = scalar
+		poly[i] = scalar
 	}
-
 	return poly, nil
 }
 
@@ -130,23 +130,23 @@ func DeserializeBlob(blob Blob) (kzg.Polynomial, error) {
 //
 // [bytes_to_bls_field]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bytes_to_bls_field
 func DeserializeScalar(serScalar Scalar) (fr.Element, error) {
-	// gnark uses big-endian but the format according to the specs is little-endian
-	// so we reverse the scalar
+	// Gnark uses big-endian but the format according to the
+	// specs is little-endian, so we reverse the scalar.
 	utils.Reverse(serScalar[:])
 	scalar, err := utils.ReduceCanonical(serScalar[:])
 	if err != nil {
 		return fr.Element{}, ErrNonCanonicalScalar
 	}
-
 	return scalar, nil
 }
 
 // SerializeScalar converts a [fr.Element] to [Scalar].
 func SerializeScalar(element fr.Element) Scalar {
-	byts := element.Bytes()
-	utils.Reverse(byts[:])
-
-	return byts
+	// Gnark uses big-endian but the format according to the
+	// specs is little-endian, so we reverse the scalar.
+	serScalar := element.Bytes()
+	utils.Reverse(serScalar[:])
+	return serScalar
 }
 
 // SerializePoly converts a [kzg.Polynomial] to [Blob].
@@ -160,6 +160,5 @@ func SerializePoly(poly kzg.Polynomial) Blob {
 		serializedScalar := SerializeScalar(poly[j])
 		copy(blob[i:end], serializedScalar[:])
 	}
-
 	return blob
 }

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -14,7 +14,7 @@ import (
 func TestG1RoundTripSmoke(t *testing.T) {
 	_, _, g1Aff, _ := bls12381.Generators()
 	g1Bytes := gokzg4844.SerializeG1Point(g1Aff)
-	aff, err := gokzg4844.DeserializeG1Point(g1Bytes)
+	aff, err := gokzg4844.DeserializeKZGProof(gokzg4844.KZGProof(g1Bytes))
 	if err != nil {
 		t.Error(err)
 	}

--- a/verify.go
+++ b/verify.go
@@ -22,12 +22,12 @@ func (c *Context) VerifyKZGProof(blobCommitment KZGCommitment, inputPointBytes, 
 		return err
 	}
 
-	polynomialCommitment, err := DeserializeG1Point(G1Point(blobCommitment))
+	polynomialCommitment, err := DeserializeKZGCommitment(blobCommitment)
 	if err != nil {
 		return err
 	}
 
-	quotientCommitment, err := DeserializeG1Point(G1Point(kzgProof))
+	quotientCommitment, err := DeserializeKZGProof(kzgProof)
 	if err != nil {
 		return err
 	}
@@ -53,12 +53,12 @@ func (c *Context) VerifyBlobKZGProof(blob Blob, blobCommitment KZGCommitment, kz
 		return err
 	}
 
-	polynomialCommitment, err := DeserializeG1Point(G1Point(blobCommitment))
+	polynomialCommitment, err := DeserializeKZGCommitment(blobCommitment)
 	if err != nil {
 		return err
 	}
 
-	quotientCommitment, err := DeserializeG1Point(G1Point(kzgProof))
+	quotientCommitment, err := DeserializeKZGProof(kzgProof)
 	if err != nil {
 		return err
 	}
@@ -103,13 +103,13 @@ func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []
 		// 2a. Deserialize
 		//
 		serComm := polynomialCommitments[i]
-		polynomialCommitment, err := DeserializeG1Point(G1Point(serComm))
+		polynomialCommitment, err := DeserializeKZGCommitment(serComm)
 		if err != nil {
 			return err
 		}
 
 		kzgProof := kzgProofs[i]
-		quotientCommitment, err := DeserializeG1Point(G1Point(kzgProof))
+		quotientCommitment, err := DeserializeKZGProof(kzgProof)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Split `DeserializeG1Point` into `DeserializeKZGCommitment` and `DeserializeKZGProof`.
  * This better matches the spec and doesn't require casts anymore.
* Rename `DeserializeG1Point` to `deserializeG1Point` (to make private).
* Group constants and types.
  * Move `CompressedG1Size` & `CompressedG2Size` to top.
  * This just because I like to group the spec constants together.
* Reimplement `DeserializeBlob` to better match the spec.
  * It's a lot cleaner now IMO too.
  * Since `Blob` is a well-defined type, we don't need to check it's length. 