### PR TITLE
Replace []fr.Element with Polynomial in some places

### DIFF
--- a/internal/kzg/domain_test.go
+++ b/internal/kzg/domain_test.go
@@ -102,7 +102,7 @@ func TestEvalPolynomialSmoke(t *testing.T) {
 
 	// lagrangePoly are the evaluations of the coefficient polynomial over
 	// `domain`
-	lagrangePoly := make([]fr.Element, domain.Cardinality)
+	lagrangePoly := make(Polynomial, domain.Cardinality)
 	for i := 0; i < int(domain.Cardinality); i++ {
 		x := domain.Roots[i]
 		lagrangePoly[i] = f(x)

--- a/internal/kzg/kzg_test.go
+++ b/internal/kzg/kzg_test.go
@@ -14,7 +14,7 @@ func TestProofVerifySmoke(t *testing.T) {
 	srs, _ := newLagrangeSRSInsecure(*domain, big.NewInt(1234))
 
 	// polynomial in lagrange form
-	poly := []fr.Element{fr.NewElement(2), fr.NewElement(3), fr.NewElement(4), fr.NewElement(5)}
+	poly := Polynomial{fr.NewElement(2), fr.NewElement(3), fr.NewElement(4), fr.NewElement(5)}
 
 	comm, _ := Commit(poly, &srs.CommitKey)
 	point := samplePointOutsideDomain(*domain)
@@ -57,7 +57,7 @@ func TestComputeQuotientPolySmoke(t *testing.T) {
 
 	polyLagrange := randPoly(t, *domain)
 
-	polyEqual := func(lhs, rhs []fr.Element) bool {
+	polyEqual := func(lhs, rhs Polynomial) bool {
 		for i := 0; i < int(domain.Cardinality); i++ {
 			if !lhs[i].Equal(&rhs[i]) {
 				return false
@@ -98,18 +98,18 @@ func TestComputeQuotientPolySmoke(t *testing.T) {
 }
 
 // This is the way it is done in the consensus-specs
-func computeQuotientPolySlow(domain Domain, f Polynomial, z fr.Element) []fr.Element {
+func computeQuotientPolySlow(domain Domain, f Polynomial, z fr.Element) Polynomial {
 	quotient := make([]fr.Element, len(f))
 	y, err := domain.EvaluateLagrangePolynomial(f, z)
 	if err != nil {
 		panic(err)
 	}
-	polyShifted := make([]fr.Element, len(f))
+	polyShifted := make(Polynomial, len(f))
 	for i := 0; i < len(f); i++ {
 		polyShifted[i].Sub(&f[i], y)
 	}
 
-	denominatorPoly := make([]fr.Element, len(f))
+	denominatorPoly := make(Polynomial, len(f))
 	for i := 0; i < len(f); i++ {
 		denominatorPoly[i].Sub(&domain.Roots[i], &z)
 	}
@@ -127,7 +127,7 @@ func computeQuotientPolySlow(domain Domain, f Polynomial, z fr.Element) []fr.Ele
 	return quotient
 }
 
-func computeQuotientEvalWithinDomain(domain Domain, z fr.Element, polynomial []fr.Element, y fr.Element) fr.Element {
+func computeQuotientEvalWithinDomain(domain Domain, z fr.Element, polynomial Polynomial, y fr.Element) fr.Element {
 	var result fr.Element
 	for i := 0; i < int(domain.Cardinality); i++ {
 		omega := domain.Roots[i]
@@ -160,9 +160,9 @@ func randValidOpeningProof(t *testing.T, domain Domain, srs SRS) (OpeningProof, 
 	return proof, *comm
 }
 
-func randPoly(t *testing.T, domain Domain) []fr.Element {
+func randPoly(t *testing.T, domain Domain) Polynomial {
 	t.Helper()
-	var poly []fr.Element
+	var poly Polynomial
 	for i := 0; i < int(domain.Cardinality); i++ {
 		randFr := randomScalarNotInDomain(t, domain)
 		poly = append(poly, randFr)

--- a/internal/kzg/srs.go
+++ b/internal/kzg/srs.go
@@ -2,7 +2,6 @@ package kzg
 
 import (
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
-	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-kzg-4844/internal/multiexp"
 )
 
@@ -48,7 +47,7 @@ type SRS struct {
 
 // Commit commits to a polynomial using a multi exponentiation with the
 // Commitment key.
-func Commit(p []fr.Element, ck *CommitKey) (*Commitment, error) {
+func Commit(p Polynomial, ck *CommitKey) (*Commitment, error) {
 	if len(p) == 0 || len(p) > len(ck.G1) {
 		return nil, ErrInvalidPolynomialSize
 	}

--- a/internal/kzg/srs_test.go
+++ b/internal/kzg/srs_test.go
@@ -16,7 +16,7 @@ func TestLagrangeSRSSmoke(t *testing.T) {
 	srsMonomial, _ := newMonomialSRSInsecure(*domain, big.NewInt(100))
 
 	// 1 + x + x^2
-	polyMonomial := []fr.Element{fr.One(), fr.One(), fr.One()}
+	polyMonomial := Polynomial{fr.One(), fr.One(), fr.One()}
 	f := func(x fr.Element) fr.Element {
 		one := fr.One()
 		var tmp fr.Element
@@ -25,7 +25,7 @@ func TestLagrangeSRSSmoke(t *testing.T) {
 		tmp.Add(&tmp, &one)
 		return tmp
 	}
-	polyLagrange := []fr.Element{f(domain.Roots[0]), f(domain.Roots[1]), f(domain.Roots[2]), f(domain.Roots[3])}
+	polyLagrange := Polynomial{f(domain.Roots[0]), f(domain.Roots[1]), f(domain.Roots[2]), f(domain.Roots[3])}
 
 	commitmentLagrange, _ := Commit(polyLagrange, &srsLagrange.CommitKey)
 	commitmentMonomial, _ := Commit(polyMonomial, &srsMonomial.CommitKey)
@@ -36,7 +36,7 @@ func TestCommitRegression(t *testing.T) {
 	domain := NewDomain(4)
 	srsLagrange, _ := newLagrangeSRSInsecure(*domain, big.NewInt(100))
 
-	poly := []fr.Element{fr.NewElement(12345), fr.NewElement(123456), fr.NewElement(1234567), fr.NewElement(12345678)}
+	poly := Polynomial{fr.NewElement(12345), fr.NewElement(123456), fr.NewElement(1234567), fr.NewElement(12345678)}
 	cLagrange, _ := Commit(poly, &srsLagrange.CommitKey)
 	cLagrangeBytes := cLagrange.Bytes()
 	gotCommitment := hex.EncodeToString(cLagrangeBytes[:])


### PR DESCRIPTION
Where it makes sense to, replace `[]fr.Element` with `Polynomial`.

These are the exact same, but I believe `Polynomial` helps readability.