### PR TITLE
Convert markdown links in Go files to Go style

### DIFF
--- a/fiatshamir.go
+++ b/fiatshamir.go
@@ -15,7 +15,9 @@ import (
 // [FIAT_SHAMIR_PROTOCOL_DOMAIN]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#blob
 const DomSepProtocol = "FSBLOBVERIFY_V1_"
 
-// computeChallenge is provided to match the spec at [compute_challenge](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_challenge)
+// computeChallenge is provided to match the spec at [compute_challenge].
+//
+// [compute_challenge]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_challenge
 func computeChallenge(blob Blob, commitment KZGCommitment) fr.Element {
 	polyDegreeBytes := u64ToByteArray16(ScalarsPerBlob)
 	data := append([]byte(DomSepProtocol), polyDegreeBytes...)
@@ -25,7 +27,9 @@ func computeChallenge(blob Blob, commitment KZGCommitment) fr.Element {
 	return hashToBLSField(data)
 }
 
-// hashToBLSField hashed the given binary data to a field element according to [hash_to_bls_field](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#hash_to_bls_field)
+// hashToBLSField hashed the given binary data to a field element according to [hash_to_bls_field].
+//
+// [hash_to_bls_field]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#hash_to_bls_field
 func hashToBLSField(data []byte) fr.Element {
 	digest := sha256.Sum256(data)
 

--- a/internal/kzg/domain.go
+++ b/internal/kzg/domain.go
@@ -41,11 +41,13 @@ type Domain struct {
 	PreComputedInverses []fr.Element
 }
 
-// Modified from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/fft/domain.go#L66)
-
 // NewDomain returns a new domain with the desired number of points x.
 //
 // We only support powers of 2 for x.
+//
+// Modified from [gnark-crypto].
+//
+// [gnark-crypto]: https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/fft/domain.go#L66
 func NewDomain(x uint64) *Domain {
 	if bits.OnesCount64(x) != 1 {
 		panic(fmt.Sprintf("x (%d) is not a power of 2. This library only supports domain sizes that are powers of two", x))
@@ -117,9 +119,10 @@ to think about all these when you add DAS.
 // This is in no way needed for basic KZG and is included in this library as
 // a stepping-stone to full Dank-sharding.
 //
-// Modified from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/fft/fft.go#L245)
+// Modified from [gnark-crypto].
 //
-// [bit_reverse](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#reverse_bits)
+// [bit_reverse]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#reverse_bits
+// [gnark-crypto]: https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/fft/fft.go#L245
 func bitReverse[K interface{}](list []K) {
 	n := uint64(len(list))
 	if !utils.IsPowerOfTwo(n) {
@@ -142,7 +145,7 @@ func bitReverse[K interface{}](list []K) {
 
 // ReverseRoots applies the bit-reversal permutation to the list of precomputed roots of unity and their inverses in the domain.
 //
-// [bit_reversal_permutation](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bit_reversal_permutation)
+// [bit_reversal_permutation]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bit_reversal_permutation
 func (domain *Domain) ReverseRoots() {
 	bitReverse(domain.Roots)
 	bitReverse(domain.PreComputedInverses)
@@ -167,7 +170,7 @@ func (domain *Domain) findRootIndex(point fr.Element) int64 {
 // The input polynomial is given in evaluation form, meaning a list of evaluations at the points in the domain.
 // If len(poly) != domain.Cardinality, returns an error.
 //
-// [evaluate_polynomial_in_evaluation_form](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#evaluate_polynomial_in_evaluation_form)
+// [evaluate_polynomial_in_evaluation_form]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#evaluate_polynomial_in_evaluation_form
 func (domain *Domain) EvaluateLagrangePolynomial(poly Polynomial, evalPoint fr.Element) (*fr.Element, error) {
 	outputPoint, _, err := domain.evaluateLagrangePolynomial(poly, evalPoint)
 

--- a/internal/kzg/domain.go
+++ b/internal/kzg/domain.go
@@ -121,8 +121,9 @@ to think about all these when you add DAS.
 //
 // Modified from [gnark-crypto].
 //
-// [reverse_bits]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#reverse_bits
 // [gnark-crypto]: https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/fft/fft.go#L245
+//
+// [reverse_bits]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#reverse_bits
 func bitReverse[K interface{}](list []K) {
 	n := uint64(len(list))
 	if !utils.IsPowerOfTwo(n) {

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -6,7 +6,7 @@ import (
 
 // Open creates a Create a KZG proof that a polynomial f(x) when evaluated at a point `z` is equal to `f(z)`
 //
-// [compute_kzg_proof_impl](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_kzg_proof_impl)
+// [compute_kzg_proof_impl]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_kzg_proof_impl
 func Open(domain *Domain, p Polynomial, evaluationPoint fr.Element, ck *CommitKey) (OpeningProof, error) {
 	if len(p) == 0 || len(p) > len(ck.G1) {
 		return OpeningProof{}, ErrInvalidPolynomialSize
@@ -72,7 +72,7 @@ func (domain *Domain) computeQuotientPoly(f Polynomial, indexInDomain int64, fz,
 
 // computeQuotientPolyOutsideDomain computes q(X) = (f(X) - f(z)) / (X - z) in lagrange form where `z` is not in the domain.
 //
-// This is the implementation of [computeQuotientPoly] for the case where z is not in the domain.
+// This is the implementation of computeQuotientPoly for the case where z is not in the domain.
 // Since both input and output polynomials are given in evaluation form, this method just performs the desired operation pointwise.
 func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.Element) (Polynomial, error) {
 	// Compute the lagrange form the of the numerator f(X) - f(z)
@@ -107,9 +107,9 @@ func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.El
 
 // computeQuotientPolyOnDomain computes (f(X) - f(z)) / (X - z) in Lagrange form where `z` is in the domain.
 //
-// This is the implementation of [computeQuotientPoly] for the case where the evaluation point is in the domain.
+// This is the implementation of computeQuotientPoly for the case where the evaluation point is in the domain.
 //
-// [compute_quotient_eval_within_domain](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain)
+// [compute_quotient_eval_within_domain]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain
 func (domain *Domain) computeQuotientPolyOnDomain(f Polynomial, index uint64) (Polynomial, error) {
 	fz := f[index]
 	z := domain.Roots[index]

--- a/internal/kzg/srs_insecure.go
+++ b/internal/kzg/srs_insecure.go
@@ -53,8 +53,10 @@ func newSRSInsecure(domain Domain, bAlpha *big.Int, convertToLagrange bool) (*SR
 // to match the other functions is defined in the testing code.
 //
 // This method should not be used in production because as the secret is supplied as input.
-
-// Copied from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/kzg/kzg.go#L65)
+//
+// Copied from [gnark-crypto].
+//
+// [gnark-crypto]: https://github.com/ConsenSys/gnark-crypto/blob/8f7ca09273c24ed9465043566906cbecf5dcee91/ecc/bls12-381/fr/kzg/kzg.go#L65
 func newMonomialSRSInsecureUint64(size uint64, bAlpha *big.Int) (*SRS, error) {
 	if size < 2 {
 		return nil, ErrMinSRSSize

--- a/internal/multiexp/multiexp.go
+++ b/internal/multiexp/multiexp.go
@@ -11,7 +11,7 @@ import (
 // More precisely, the result is set to scalars[0]*points[0] + ... + scalars[n-1]*points[n-1], where n is the length of both slices
 // If the slices differ in length, this function returns an error.
 //
-// [g1_lincomb](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#g1_lincomb)
+// [g1_lincomb]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#g1_lincomb
 func MultiExp(scalars []fr.Element, points []bls12381.G1Affine) (*bls12381.G1Affine, error) {
 	return new(bls12381.G1Affine).MultiExp(points, scalars, ecc.MultiExpConfig{})
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -10,15 +10,15 @@ import (
 // however note that this is not utilized in the specs anywhere
 // and so it is also fine to panic on zero.
 //
-// [bls_modular_inverse](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bls_modular_inverse)
-// [div](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#div)
+// [bls_modular_inverse]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#bls_modular_inverse
+// [div]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#div
 
 // ComputePowers computes x^0 to x^n-1.
 //
 // More precisely, given x and n, returns a slice containing [x^0, ..., x^n-1]
 // In particular, for n==0, an empty slice is returned
 //
-// [compute_powers](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_powers)
+// [compute_powers]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#compute_powers
 func ComputePowers(x fr.Element, n uint) []fr.Element {
 	if n == 0 {
 		return []fr.Element{}
@@ -37,7 +37,7 @@ func ComputePowers(x fr.Element, n uint) []fr.Element {
 //
 // `0` will return false
 //
-// [is_power_of_two](https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#is_power_of_two)
+// [is_power_of_two]: https://github.com/ethereum/consensus-specs/blob/3a2304981a3b820a22b518fe4859f4bba0ebc83b/specs/deneb/polynomial-commitments.md#is_power_of_two
 func IsPowerOfTwo(value uint64) bool {
 	return value > 0 && (value&(value-1) == 0)
 }


### PR DESCRIPTION
This converts the remaining markdown links in Go files to Go style.

* From `[link](https://example.com)` to `[link]: https://example.com`.
* Still need to update documentation to use the links in some places.
  * I think this should be done in a different PR. 