### PR TITLE
Fix: Returning nil on error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     # Maybe fix later:
     #
     - goerr113
-    - nilerr
     - stylecheck
     - tagliatelle
 

--- a/internal/kzg/kzg_verify.go
+++ b/internal/kzg/kzg_verify.go
@@ -147,7 +147,7 @@ func BatchVerifyMultiPoints(commitments []Commitment, proofs []OpeningProof, ope
 	config := ecc.MultiExpConfig{}
 	_, err = foldedQuotients.MultiExp(quotients, randomNumbers, config)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// Fold commitments and evaluations using randomness


### PR DESCRIPTION
Found by @jtraglia -- the offending line was ignoring the error. 

It was never caught in tests because the conditions to make an error were always checked for in the section that deserializes and validates Blobs.