### PR TITLE
Add config parameter to set the number of go routines

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,5 +5,6 @@ import "errors"
 var (
 	ErrBatchLengthCheck               = errors.New("the number of blobs, commitments, and proofs must be the same")
 	ErrNonCanonicalScalar             = errors.New("scalar is not canonical when interpreted as a big integer in little-endian")
+	ErrTooManyGoRoutines              = errors.New("cannot configure more than 1024 go routines")
 	errLagrangeMonomialLengthMismatch = errors.New("the number of points in monomial SRS should equal number of points in lagrange SRS")
 )

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -6,8 +6,11 @@ import (
 
 // Open verifies that a polynomial f(x) when evaluated at a point `z` is equal to `f(z)`
 //
+// numGoRoutines is used to configure the amount of concurrency needed. Setting this
+// value to a negative number or 0 will make it default to the number of CPUs.
+//
 // [compute_kzg_proof_impl]: https://github.com/ethereum/consensus-specs/blob/50a3f8e8d902ad9d677ca006302eb9535d56d758/specs/deneb/polynomial-commitments.md#compute_kzg_proof_impl
-func Open(domain *Domain, p Polynomial, evaluationPoint fr.Element, ck *CommitKey) (OpeningProof, error) {
+func Open(domain *Domain, p Polynomial, evaluationPoint fr.Element, ck *CommitKey, numGoRoutines int) (OpeningProof, error) {
 	if len(p) == 0 || len(p) > len(ck.G1) {
 		return OpeningProof{}, ErrInvalidPolynomialSize
 	}
@@ -24,7 +27,7 @@ func Open(domain *Domain, p Polynomial, evaluationPoint fr.Element, ck *CommitKe
 	}
 
 	// Commit to Quotient polynomial
-	quotientCommit, err := Commit(quotientPoly, ck)
+	quotientCommit, err := Commit(quotientPoly, ck, numGoRoutines)
 	if err != nil {
 		return OpeningProof{}, err
 	}

--- a/internal/kzg/kzg_test.go
+++ b/internal/kzg/kzg_test.go
@@ -16,9 +16,9 @@ func TestProofVerifySmoke(t *testing.T) {
 	// polynomial in lagrange form
 	poly := Polynomial{fr.NewElement(2), fr.NewElement(3), fr.NewElement(4), fr.NewElement(5)}
 
-	comm, _ := Commit(poly, &srs.CommitKey)
+	comm, _ := Commit(poly, &srs.CommitKey, 0)
 	point := samplePointOutsideDomain(*domain)
-	proof, _ := Open(domain, poly, *point, &srs.CommitKey)
+	proof, _ := Open(domain, poly, *point, &srs.CommitKey, 0)
 
 	err := Verify(comm, &proof, &srs.OpeningKey)
 	if err != nil {
@@ -154,9 +154,9 @@ func computeQuotientEvalWithinDomain(domain Domain, z fr.Element, polynomial Pol
 func randValidOpeningProof(t *testing.T, domain Domain, srs SRS) (OpeningProof, Commitment) {
 	t.Helper()
 	poly := randPoly(t, domain)
-	comm, _ := Commit(poly, &srs.CommitKey)
+	comm, _ := Commit(poly, &srs.CommitKey, 0)
 	point := samplePointOutsideDomain(domain)
-	proof, _ := Open(&domain, poly, *point, &srs.CommitKey)
+	proof, _ := Open(&domain, poly, *point, &srs.CommitKey, 0)
 	return proof, *comm
 }
 

--- a/internal/kzg/srs.go
+++ b/internal/kzg/srs.go
@@ -47,10 +47,13 @@ type SRS struct {
 
 // Commit commits to a polynomial using a multi exponentiation with the
 // Commitment key.
-func Commit(p Polynomial, ck *CommitKey) (*Commitment, error) {
+//
+// numGoRoutines is used to configure the amount of concurrency needed. Setting this
+// value to a negative number or 0 will make it default to the number of CPUs.
+func Commit(p Polynomial, ck *CommitKey, numGoRoutines int) (*Commitment, error) {
 	if len(p) == 0 || len(p) > len(ck.G1) {
 		return nil, ErrInvalidPolynomialSize
 	}
 
-	return multiexp.MultiExp(p, ck.G1[:len(p)])
+	return multiexp.MultiExp(p, ck.G1[:len(p)], numGoRoutines)
 }

--- a/internal/kzg/srs_test.go
+++ b/internal/kzg/srs_test.go
@@ -27,8 +27,8 @@ func TestLagrangeSRSSmoke(t *testing.T) {
 	}
 	polyLagrange := Polynomial{f(domain.Roots[0]), f(domain.Roots[1]), f(domain.Roots[2]), f(domain.Roots[3])}
 
-	commitmentLagrange, _ := Commit(polyLagrange, &srsLagrange.CommitKey)
-	commitmentMonomial, _ := Commit(polyMonomial, &srsMonomial.CommitKey)
+	commitmentLagrange, _ := Commit(polyLagrange, &srsLagrange.CommitKey, 0)
+	commitmentMonomial, _ := Commit(polyMonomial, &srsMonomial.CommitKey, 0)
 	require.Equal(t, commitmentLagrange, commitmentMonomial)
 }
 
@@ -37,7 +37,7 @@ func TestCommitRegression(t *testing.T) {
 	srsLagrange, _ := newLagrangeSRSInsecure(*domain, big.NewInt(100))
 
 	poly := Polynomial{fr.NewElement(12345), fr.NewElement(123456), fr.NewElement(1234567), fr.NewElement(12345678)}
-	cLagrange, _ := Commit(poly, &srsLagrange.CommitKey)
+	cLagrange, _ := Commit(poly, &srsLagrange.CommitKey, 0)
 	cLagrangeBytes := cLagrange.Bytes()
 	gotCommitment := hex.EncodeToString(cLagrangeBytes[:])
 	expectedCommitment := "85bdf872da5b8561d23055d32db3fc86c672b0be7543b8c1e48634af07231bf7ab6385b765750921017cbcdbcd14f8e0"

--- a/internal/multiexp/multiexp.go
+++ b/internal/multiexp/multiexp.go
@@ -11,7 +11,10 @@ import (
 // More precisely, the result is set to scalars[0]*points[0] + ... + scalars[n-1]*points[n-1], where n is the length of both slices
 // If the slices differ in length, this function returns an error.
 //
+// numGoRoutines is used to configure the amount of concurrency needed. Setting this
+// value to a negative number or 0 will make it default to the number of CPUs.
+//
 // [g1_lincomb]: https://github.com/ethereum/consensus-specs/blob/50a3f8e8d902ad9d677ca006302eb9535d56d758/specs/deneb/polynomial-commitments.md#g1_lincomb
-func MultiExp(scalars []fr.Element, points []bls12381.G1Affine) (*bls12381.G1Affine, error) {
-	return new(bls12381.G1Affine).MultiExp(points, scalars, ecc.MultiExpConfig{})
+func MultiExp(scalars []fr.Element, points []bls12381.G1Affine, numGoRoutines int) (*bls12381.G1Affine, error) {
+	return new(bls12381.G1Affine).MultiExp(points, scalars, ecc.MultiExpConfig{NbTasks: numGoRoutines})
 }

--- a/internal/multiexp/multiexp_test.go
+++ b/internal/multiexp/multiexp_test.go
@@ -19,7 +19,7 @@ func TestMultiExpSmoke(t *testing.T) {
 	powers := utils.ComputePowers(base, instanceSize)
 	points := genG1Points(instanceSize)
 
-	got, err := MultiExp(powers, points)
+	got, err := MultiExp(powers, points, -1)
 	if err != nil {
 		t.Fail()
 	}
@@ -41,21 +41,21 @@ func TestMultiExpMismatchedLength(t *testing.T) {
 	powers := utils.ComputePowers(base, instanceSize)
 	points := genG1Points(instanceSize + 1)
 
-	_, err := MultiExp(powers, points)
+	_, err := MultiExp(powers, points, 0)
 	if err == nil {
 		t.Error("number of points != number of scalars. Should produce an error")
 	}
 
 	powers = utils.ComputePowers(base, instanceSize+1)
 	points = genG1Points(instanceSize)
-	_, err = MultiExp(powers, points)
+	_, err = MultiExp(powers, points, 0)
 	if err == nil {
 		t.Error("number of points != number of scalars. Should produce an error")
 	}
 }
 
 func TestMultiExpZeroLength(t *testing.T) {
-	result, err := MultiExp([]fr.Element{}, []bls12381.G1Affine{})
+	result, err := MultiExp([]fr.Element{}, []bls12381.G1Affine{}, 0)
 	if err != nil {
 		t.Error("number of points != number of scalars. Should produce an error")
 	}

--- a/prove.go
+++ b/prove.go
@@ -17,7 +17,7 @@ func (c *Context) BlobToKZGCommitment(blob Blob) (KZGCommitment, error) {
 	}
 
 	// 2. Commit to polynomial
-	commitment, err := kzg.Commit(polynomial, c.commitKey)
+	commitment, err := kzg.Commit(polynomial, c.commitKey, c.numGoRoutines)
 	if err != nil {
 		return KZGCommitment{}, err
 	}
@@ -57,7 +57,7 @@ func (c *Context) ComputeBlobKZGProof(blob Blob, blobCommitment KZGCommitment) (
 	evaluationChallenge := computeChallenge(blob, blobCommitment)
 
 	// 3. Create opening proof
-	openingProof, err := kzg.Open(c.domain, polynomial, evaluationChallenge, c.commitKey)
+	openingProof, err := kzg.Open(c.domain, polynomial, evaluationChallenge, c.commitKey, c.numGoRoutines)
 	if err != nil {
 		return KZGProof{}, err
 	}
@@ -87,7 +87,7 @@ func (c *Context) ComputeKZGProof(blob Blob, inputPointBytes Scalar) (KZGProof, 
 	}
 
 	// 2. Create opening proof
-	openingProof, err := kzg.Open(c.domain, polynomial, inputPoint, c.commitKey)
+	openingProof, err := kzg.Open(c.domain, polynomial, inputPoint, c.commitKey, c.numGoRoutines)
 	if err != nil {
 		return KZGProof{}, [32]byte{}, err
 	}


### PR DESCRIPTION
closes #44 

More context: This sets the number of go routines when committing to a polynomial, ny exposing a way to set the gnark-crypto library parameter.