### PR TITLE
Avoid passing large arrays on heap, also use less memory

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -40,7 +40,7 @@ func TestNonCanonicalSmoke(t *testing.T) {
 	blobGood := GetRandBlob(123456789)
 	blobBad := GetRandBlob(123456789)
 	unreducedScalar := nonCanonicalScalar(123445)
-	modifyBlob(&blobBad, unreducedScalar, 0)
+	modifyBlob(blobBad, unreducedScalar, 0)
 
 	commitment, err := ctx.BlobToKZGCommitment(blobGood, NumGoRoutines)
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestNonCanonicalSmoke(t *testing.T) {
 	err = ctx.VerifyBlobKZGProof(blobBad, commitment, blobProof)
 	require.Error(t, err, "expected an error since blob was not canonical")
 
-	err = ctx.VerifyBlobKZGProofBatch([]gokzg4844.Blob{blobBad}, []gokzg4844.KZGCommitment{commitment}, []gokzg4844.KZGProof{blobProof})
+	err = ctx.VerifyBlobKZGProofBatch([]*gokzg4844.Blob{blobBad}, []gokzg4844.KZGCommitment{commitment}, []gokzg4844.KZGProof{blobProof})
 	require.Error(t, err, "expected an error since blob was not canonical")
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -74,7 +74,7 @@ func TestNonCanonicalSmoke(t *testing.T) {
 	err = ctx.VerifyBlobKZGProof(blobBad, commitment, blobProof)
 	require.Error(t, err, "expected an error since blob was not canonical")
 
-	err = ctx.VerifyBlobKZGProofBatch([]*gokzg4844.Blob{blobBad}, []gokzg4844.KZGCommitment{commitment}, []gokzg4844.KZGProof{blobProof})
+	err = ctx.VerifyBlobKZGProofBatch([]gokzg4844.Blob{*blobBad}, []gokzg4844.KZGCommitment{commitment}, []gokzg4844.KZGProof{blobProof})
 	require.Error(t, err, "expected an error since blob was not canonical")
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -34,19 +34,19 @@ func GetRandFieldElement(seed int64) [32]byte {
 	return gokzg4844.SerializeScalar(r)
 }
 
-func GetRandBlob(seed int64) gokzg4844.Blob {
+func GetRandBlob(seed int64) *gokzg4844.Blob {
 	var blob gokzg4844.Blob
 	bytesPerBlob := gokzg4844.ScalarsPerBlob * gokzg4844.SerializedScalarSize
 	for i := 0; i < bytesPerBlob; i += gokzg4844.SerializedScalarSize {
 		fieldElementBytes := GetRandFieldElement(seed + int64(i))
 		copy(blob[i:i+gokzg4844.SerializedScalarSize], fieldElementBytes[:])
 	}
-	return blob
+	return &blob
 }
 
 func Benchmark(b *testing.B) {
 	const length = 64
-	blobs := make([]gokzg4844.Blob, length)
+	blobs := make([]*gokzg4844.Blob, length)
 	commitments := make([]gokzg4844.KZGCommitment, length)
 	proofs := make([]gokzg4844.KZGProof, length)
 	fields := make([]gokzg4844.Scalar, length)

--- a/bench_test.go
+++ b/bench_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	gokzg4844 "github.com/crate-crypto/go-kzg-4844"
+	"github.com/crate-crypto/go-kzg-4844/internal/kzg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,5 +113,27 @@ func Benchmark(b *testing.B) {
 				_ = ctx.VerifyBlobKZGProofBatchPar(blobs[:i], commitments[:i], proofs[:i])
 			}
 		})
+	}
+}
+
+func BenchmarkDeserializeBlob(b *testing.B) {
+	var (
+		blob       = GetRandBlob(int64(13))
+		first, err = gokzg4844.DeserializeBlob(blob)
+		second     kzg.Polynomial
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		second, err = gokzg4844.DeserializeBlob(blob)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	if have, want := fmt.Sprintf("%x", second), fmt.Sprintf("%x", first); have != want {
+		b.Fatalf("have %s want %s", have, want)
 	}
 }

--- a/consensus_specs_test.go
+++ b/consensus_specs_test.go
@@ -306,7 +306,7 @@ func TestVerifyBlobKZGProofBatch(t *testing.T) {
 			require.NoError(t, err)
 			testCaseValid := test.ProofIsValid != nil
 
-			var blobs []gokzg4844.Blob
+			var blobs []*gokzg4844.Blob
 			for _, b := range test.Input.Blobs {
 				blob, err := hexStrToBlob(b)
 				if err != nil {
@@ -355,18 +355,18 @@ func TestVerifyBlobKZGProofBatch(t *testing.T) {
 	}
 }
 
-func hexStrToBlob(hexStr string) (gokzg4844.Blob, error) {
+func hexStrToBlob(hexStr string) (*gokzg4844.Blob, error) {
 	var blob gokzg4844.Blob
 	byts, err := hexStrToBytes(hexStr)
 	if err != nil {
-		return blob, err
+		return nil, err
 	}
 
 	if len(blob) != len(byts) {
-		return blob, fmt.Errorf("blob does not have the correct length, %d ", len(byts))
+		return nil, fmt.Errorf("blob does not have the correct length, %d ", len(byts))
 	}
 	copy(blob[:], byts)
-	return blob, nil
+	return &blob, nil
 }
 
 func hexStrToScalar(hexStr string) (gokzg4844.Scalar, error) {

--- a/consensus_specs_test.go
+++ b/consensus_specs_test.go
@@ -306,14 +306,14 @@ func TestVerifyBlobKZGProofBatch(t *testing.T) {
 			require.NoError(t, err)
 			testCaseValid := test.ProofIsValid != nil
 
-			var blobs []*gokzg4844.Blob
+			var blobs []gokzg4844.Blob
 			for _, b := range test.Input.Blobs {
 				blob, err := hexStrToBlob(b)
 				if err != nil {
 					require.False(t, testCaseValid)
 					return
 				}
-				blobs = append(blobs, blob)
+				blobs = append(blobs, *blob)
 			}
 
 			var commitments []gokzg4844.KZGCommitment

--- a/examples_test.go
+++ b/examples_test.go
@@ -33,7 +33,7 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 
 func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 	batchSize := 5
-	blobs := make([]gokzg4844.Blob, batchSize)
+	blobs := make([]*gokzg4844.Blob, batchSize)
 	commitments := make([]gokzg4844.KZGCommitment, batchSize)
 	proofs := make([]gokzg4844.KZGProof, batchSize)
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -33,7 +33,7 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 
 func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 	batchSize := 5
-	blobs := make([]*gokzg4844.Blob, batchSize)
+	blobs := make([]gokzg4844.Blob, batchSize)
 	commitments := make([]gokzg4844.KZGCommitment, batchSize)
 	proofs := make([]gokzg4844.KZGProof, batchSize)
 
@@ -44,7 +44,7 @@ func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 		proof, err := ctx.ComputeBlobKZGProof(blob, commitment, NumGoRoutines)
 		require.NoError(t, err)
 
-		blobs[i] = blob
+		blobs[i] = *blob
 		commitments[i] = commitment
 		proofs[i] = proof
 	}

--- a/fiatshamir.go
+++ b/fiatshamir.go
@@ -17,13 +17,17 @@ const DomSepProtocol = "FSBLOBVERIFY_V1_"
 // computeChallenge is provided to match the spec at [compute_challenge].
 //
 // [compute_challenge]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_challenge
-func computeChallenge(blob Blob, commitment KZGCommitment) fr.Element {
-	polyDegreeBytes := u64ToByteArray16(ScalarsPerBlob)
-	data := append([]byte(DomSepProtocol), polyDegreeBytes...)
-	data = append(data, blob[:]...)
-	data = append(data, commitment[:]...)
+func computeChallenge(blob *Blob, commitment KZGCommitment) fr.Element {
+	h := sha256.New()
+	h.Write([]byte(DomSepProtocol))
+	h.Write(u64ToByteArray16(ScalarsPerBlob))
+	h.Write(blob[:])
+	h.Write(commitment[:])
 
-	return hashToBLSField(data)
+	digest := h.Sum(nil)
+	var challenge fr.Element
+	challenge.SetBytes(digest[:])
+	return challenge
 }
 
 // hashToBLSField hashed the given binary data to a field element according to [hash_to_bls_field].

--- a/fiatshamir.go
+++ b/fiatshamir.go
@@ -17,6 +17,8 @@ const DomSepProtocol = "FSBLOBVERIFY_V1_"
 // computeChallenge is provided to match the spec at [compute_challenge].
 //
 // [compute_challenge]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_challenge
+//
+// [hash_to_bls_field]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#hash_to_bls_field
 func computeChallenge(blob *Blob, commitment KZGCommitment) fr.Element {
 	h := sha256.New()
 	h.Write([]byte(DomSepProtocol))
@@ -27,19 +29,6 @@ func computeChallenge(blob *Blob, commitment KZGCommitment) fr.Element {
 	digest := h.Sum(nil)
 	var challenge fr.Element
 	challenge.SetBytes(digest[:])
-	return challenge
-}
-
-// hashToBLSField hashed the given binary data to a field element according to [hash_to_bls_field].
-//
-// [hash_to_bls_field]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#hash_to_bls_field
-func hashToBLSField(data []byte) fr.Element {
-	digest := sha256.Sum256(data)
-
-	// Now interpret those bytes as a field element
-	var challenge fr.Element
-	challenge.SetBytes(digest[:])
-
 	return challenge
 }
 

--- a/fiatshamir_test.go
+++ b/fiatshamir_test.go
@@ -11,7 +11,7 @@ import (
 // If the way computeChallenge is computed is updated
 // then this test will fail
 func TestComputeChallengeInterop(t *testing.T) {
-	blob := Blob{}
+	blob := &Blob{}
 	commitment := SerializeG1Point(bls12381.G1Affine{})
 	challenge := computeChallenge(blob, KZGCommitment(commitment))
 	expected := []byte{

--- a/fiatshamir_test.go
+++ b/fiatshamir_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,4 +34,25 @@ func TestTo16Bytes(t *testing.T) {
 	expected := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0}
 	got := u64ToByteArray16(number)
 	require.Equal(t, expected, got)
+}
+
+func BenchmarkComputeChallenge(b *testing.B) {
+	var (
+		blob       = &Blob{}
+		commitment = SerializeG1Point(bls12381.G1Affine{})
+		challenge  fr.Element
+		want       = []byte{
+			0x04, 0xb7, 0xb2, 0x2a, 0xf6, 0x3d, 0x2b, 0x2f,
+			0x1c, 0xed, 0x8d, 0x55, 0x05, 0x60, 0xe5, 0xd1,
+			0xe4, 0xb0, 0x1e, 0x35, 0x59, 0x03, 0xde, 0xe2,
+			0x27, 0x81, 0xe8, 0x78, 0x26, 0x85, 0x60, 0x96,
+		}
+	)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		challenge = computeChallenge(blob, KZGCommitment(commitment))
+	}
+	have := SerializeScalar(challenge)
+	require.Equal(b, want, have[:])
 }

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -137,7 +137,7 @@ func (domain *Domain) computeQuotientPolyOnDomain(f Polynomial, index uint64) (P
 	invRootsMinusZ := fr.BatchInvert(rootsMinusZ)
 
 	// The rootsMinusZ is now free to reuse, since BatchInvert returned
-	// a fresh slice. But we need to ensure to clear it on 'index'
+	// a fresh slice. But we need to ensure to set the value for 'index' to zero
 	quotientPoly := rootsMinusZ
 	quotientPoly[index] = fr.Element{}
 

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -94,7 +94,7 @@ func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.El
 	// Note: the returned slice is a new slice, thus we are free to use tmpDenom.
 	denominator := fr.BatchInvert(tmpDenom)
 
-	// Compute the lagrange form the of the numerator f(X) - f(z)
+	// Compute the lagrange form of the numerator f(X) - f(z)
 	// Since f(X) is already in lagrange form, we can compute f(X) - f(z)
 	// by shifting all elements in f(X) by f(z)
 	numerator := tmpDenom

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -78,7 +78,6 @@ func (domain *Domain) computeQuotientPoly(f Polynomial, indexInDomain int64, fz,
 // This is the implementation of computeQuotientPoly for the case where z is not in the domain.
 // Since both input and output polynomials are given in evaluation form, this method just performs the desired operation pointwise.
 func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.Element) (Polynomial, error) {
-
 	// Compute the lagrange form of the denominator X - z.
 	// This means that we need to compute w - z for all points w in the domain.
 	tmpDenom := make(Polynomial, len(f))

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -78,19 +78,12 @@ func (domain *Domain) computeQuotientPoly(f Polynomial, indexInDomain int64, fz,
 // This is the implementation of computeQuotientPoly for the case where z is not in the domain.
 // Since both input and output polynomials are given in evaluation form, this method just performs the desired operation pointwise.
 func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.Element) (Polynomial, error) {
-	// Compute the lagrange form the of the numerator f(X) - f(z)
-	// Since f(X) is already in lagrange form, we can compute f(X) - f(z)
-	// by shifting all elements in f(X) by f(z)
-	numerator := make(Polynomial, len(f))
-	for i := 0; i < len(f); i++ {
-		numerator[i].Sub(&f[i], &fz)
-	}
 
 	// Compute the lagrange form of the denominator X - z.
 	// This means that we need to compute w - z for all points w in the domain.
-	denominator := make(Polynomial, len(f))
+	tmpDenom := make(Polynomial, len(f))
 	for i := 0; i < len(f); i++ {
-		denominator[i].Sub(&domain.Roots[i], &z)
+		tmpDenom[i].Sub(&domain.Roots[i], &z)
 	}
 
 	// To invert the denominator polynomial at each point of the domain, we perform a batch-inversion.
@@ -98,7 +91,16 @@ func (domain *Domain) computeQuotientPolyOutsideDomain(f Polynomial, fz, z fr.El
 	//
 	// Note: if there was a zero, the gnark-crypto library would skip
 	// it and not panic.
-	denominator = fr.BatchInvert(denominator)
+	// Note: the returned slice is a new slice, thus we are free to use tmpDenom.
+	denominator := fr.BatchInvert(tmpDenom)
+
+	// Compute the lagrange form the of the numerator f(X) - f(z)
+	// Since f(X) is already in lagrange form, we can compute f(X) - f(z)
+	// by shifting all elements in f(X) by f(z)
+	numerator := tmpDenom
+	for i := 0; i < len(f); i++ {
+		numerator[i].Sub(&f[i], &fz)
+	}
 
 	// Compute the quotient q(X)
 	for i := 0; i < len(f); i++ {
@@ -134,7 +136,11 @@ func (domain *Domain) computeQuotientPolyOnDomain(f Polynomial, index uint64) (P
 	// Evaluation of 1/(X-z) at every point of the domain, except for index.
 	invRootsMinusZ := fr.BatchInvert(rootsMinusZ)
 
-	quotientPoly := make(Polynomial, domain.Cardinality)
+	// The rootsMinusZ is now free to reuse, since BatchInvert returned
+	// a fresh slice. But we need to ensure to clear it on 'index'
+	quotientPoly := rootsMinusZ
+	quotientPoly[index] = fr.Element{}
+
 	for j := 0; j < int(domain.Cardinality); j++ {
 		// Check if we are on the current root of unity
 		// Note: For notations below, we use `m` to denote `index`

--- a/prove.go
+++ b/prove.go
@@ -10,7 +10,7 @@ import (
 // value to a negative number or 0 will make it default to the number of CPUs.
 //
 // [blob_to_kzg_commitment]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#blob_to_kzg_commitment
-func (c *Context) BlobToKZGCommitment(blob Blob, numGoRoutines int) (KZGCommitment, error) {
+func (c *Context) BlobToKZGCommitment(blob *Blob, numGoRoutines int) (KZGCommitment, error) {
 	// 1. Deserialization
 	//
 	// Deserialize blob into polynomial
@@ -43,7 +43,7 @@ func (c *Context) BlobToKZGCommitment(blob Blob, numGoRoutines int) (KZGCommitme
 // value to a negative number or 0 will make it default to the number of CPUs.
 //
 // [compute_blob_kzg_proof]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_blob_kzg_proof
-func (c *Context) ComputeBlobKZGProof(blob Blob, blobCommitment KZGCommitment, numGoRoutines int) (KZGProof, error) {
+func (c *Context) ComputeBlobKZGProof(blob *Blob, blobCommitment KZGCommitment, numGoRoutines int) (KZGProof, error) {
 	// 1. Deserialization
 	//
 	polynomial, err := DeserializeBlob(blob)
@@ -82,7 +82,7 @@ func (c *Context) ComputeBlobKZGProof(blob Blob, blobCommitment KZGCommitment, n
 // value to a negative number or 0 will make it default to the number of CPUs.
 //
 // [compute_kzg_proof]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_kzg_proof
-func (c *Context) ComputeKZGProof(blob Blob, inputPointBytes Scalar, numGoRoutines int) (KZGProof, Scalar, error) {
+func (c *Context) ComputeKZGProof(blob *Blob, inputPointBytes Scalar, numGoRoutines int) (KZGProof, Scalar, error) {
 	// 1. Deserialization
 	//
 	polynomial, err := DeserializeBlob(blob)

--- a/verify.go
+++ b/verify.go
@@ -85,7 +85,7 @@ func (c *Context) VerifyBlobKZGProof(blob *Blob, blobCommitment KZGCommitment, k
 // VerifyBlobKZGProofBatch implements [verify_blob_kzg_proof_batch].
 //
 // [verify_blob_kzg_proof_batch]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
-func (c *Context) VerifyBlobKZGProofBatch(blobs []*Blob, polynomialCommitments []KZGCommitment, kzgProofs []KZGProof) error {
+func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []KZGCommitment, kzgProofs []KZGProof) error {
 	// 1. Check that all components in the batch have the same size
 	//
 	blobsLen := len(blobs)
@@ -114,7 +114,7 @@ func (c *Context) VerifyBlobKZGProofBatch(blobs []*Blob, polynomialCommitments [
 			return err
 		}
 
-		blob := blobs[i]
+		blob := &blobs[i]
 		polynomial, err := DeserializeBlob(blob)
 		if err != nil {
 			return err
@@ -149,7 +149,7 @@ func (c *Context) VerifyBlobKZGProofBatch(blobs []*Blob, polynomialCommitments [
 // go-routines in a more intricate way than done below for large batches.
 //
 // [verify_blob_kzg_proof_batch]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
-func (c *Context) VerifyBlobKZGProofBatchPar(blobs []*Blob, commitments []KZGCommitment, proofs []KZGProof) error {
+func (c *Context) VerifyBlobKZGProofBatchPar(blobs []Blob, commitments []KZGCommitment, proofs []KZGProof) error {
 	// 1. Check that all components in the batch have the same size
 	if len(commitments) != len(blobs) || len(proofs) != len(blobs) {
 		return ErrBatchLengthCheck
@@ -160,7 +160,7 @@ func (c *Context) VerifyBlobKZGProofBatchPar(blobs []*Blob, commitments []KZGCom
 	for i := range blobs {
 		j := i // Capture the value of the loop variable
 		errG.Go(func() error {
-			return c.VerifyBlobKZGProof(blobs[j], commitments[j], proofs[j])
+			return c.VerifyBlobKZGProof(&blobs[j], commitments[j], proofs[j])
 		})
 	}
 

--- a/verify.go
+++ b/verify.go
@@ -45,7 +45,7 @@ func (c *Context) VerifyKZGProof(blobCommitment KZGCommitment, inputPointBytes, 
 // VerifyBlobKZGProof implements [verify_blob_kzg_proof].
 //
 // [verify_blob_kzg_proof]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof
-func (c *Context) VerifyBlobKZGProof(blob Blob, blobCommitment KZGCommitment, kzgProof KZGProof) error {
+func (c *Context) VerifyBlobKZGProof(blob *Blob, blobCommitment KZGCommitment, kzgProof KZGProof) error {
 	// 1. Deserialize
 	//
 	polynomial, err := DeserializeBlob(blob)
@@ -85,7 +85,7 @@ func (c *Context) VerifyBlobKZGProof(blob Blob, blobCommitment KZGCommitment, kz
 // VerifyBlobKZGProofBatch implements [verify_blob_kzg_proof_batch].
 //
 // [verify_blob_kzg_proof_batch]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
-func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []KZGCommitment, kzgProofs []KZGProof) error {
+func (c *Context) VerifyBlobKZGProofBatch(blobs []*Blob, polynomialCommitments []KZGCommitment, kzgProofs []KZGProof) error {
 	// 1. Check that all components in the batch have the same size
 	//
 	blobsLen := len(blobs)
@@ -149,7 +149,7 @@ func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []
 // go-routines in a more intricate way than done below for large batches.
 //
 // [verify_blob_kzg_proof_batch]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
-func (c *Context) VerifyBlobKZGProofBatchPar(blobs []Blob, commitments []KZGCommitment, proofs []KZGProof) error {
+func (c *Context) VerifyBlobKZGProofBatchPar(blobs []*Blob, commitments []KZGCommitment, proofs []KZGProof) error {
 	// 1. Check that all components in the batch have the same size
 	if len(commitments) != len(blobs) || len(proofs) != len(blobs) {
 		return ErrBatchLengthCheck


### PR DESCRIPTION
This PR does a couple of things. 

First of all, it changes the public interface methods that currently pass `Blob`  by value, to instead pass `*Blob`, that is , by  reference. 

**NOTE**: This means that this PR creates a breaking change, which requires a major version-upgrade of this library, strictly speaking. :warning: 

The `Blob` type is an `array`, of 130K bytes. As opposed to a slice of similar size, when an array is passed by value, every byte is passed over the heap. 


Secondly, this PR pushes this change a bit further into the library, and also spot-fixes some places where memory usage can be reduced. 

This PR on it's own doesn't really make a lot of difference. However, when an external user, e.g. geth, calls this library, the heap-copying might make more of a difference, since inlining cannot be performed. 

Anyway, these are the differences I get with the existing benchmarks. 
```
name                                     old time/op    new time/op    delta
/BlobToKZGCommitment-8                     24.8ms ± 3%    24.5ms ± 2%     ~     (p=0.730 n=5+4)
/ComputeKZGProof-8                         30.9ms ±11%    27.9ms ± 2%     ~     (p=0.095 n=5+5)
/ComputeBlobKZGProof-8                     32.6ms ± 2%    33.1ms ±11%     ~     (p=0.690 n=5+5)
/VerifyKZGProof-8                          3.35ms ±45%    2.51ms ±17%     ~     (p=0.548 n=5+5)
/VerifyBlobKZGProof-8                      5.12ms ±32%    5.45ms ±25%     ~     (p=0.841 n=5+5)
/VerifyBlobKZGProofBatch(count=1)-8        5.67ms ±27%    5.31ms ±15%     ~     (p=0.841 n=5+5)
/VerifyBlobKZGProofBatch(count=2)-8        10.8ms ± 9%    10.7ms ± 6%     ~     (p=0.841 n=5+5)
/VerifyBlobKZGProofBatch(count=4)-8        17.4ms ± 5%    16.5ms ± 3%     ~     (p=0.056 n=5+5)
/VerifyBlobKZGProofBatch(count=8)-8        28.6ms ± 5%    26.7ms ±10%     ~     (p=0.151 n=5+5)
/VerifyBlobKZGProofBatch(count=16)-8       47.8ms ±14%    49.0ms ± 5%     ~     (p=0.690 n=5+5)
/VerifyBlobKZGProofBatch(count=32)-8       90.4ms ±15%    87.6ms ±10%     ~     (p=1.000 n=5+5)
/VerifyBlobKZGProofBatch(count=64)-8        168ms ± 7%     156ms ± 5%     ~     (p=0.056 n=5+5)
/VerifyBlobKZGProofBatchPar(count=1)-8     6.25ms ± 3%    5.65ms ±25%     ~     (p=0.310 n=5+5)
/VerifyBlobKZGProofBatchPar(count=2)-8     6.56ms ±13%    7.11ms ± 8%     ~     (p=0.151 n=5+5)
/VerifyBlobKZGProofBatchPar(count=4)-8     8.43ms ± 3%    8.14ms ± 3%     ~     (p=0.056 n=5+5)
/VerifyBlobKZGProofBatchPar(count=8)-8     11.0ms ± 6%     9.8ms ± 3%  -10.66%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=16)-8    18.3ms ±10%    18.0ms ± 5%     ~     (p=1.000 n=5+5)
/VerifyBlobKZGProofBatchPar(count=32)-8    27.9ms ± 2%    30.1ms ± 7%   +7.78%  (p=0.032 n=4+5)
/VerifyBlobKZGProofBatchPar(count=64)-8    54.4ms ± 5%    56.8ms ±10%     ~     (p=0.222 n=5+5)

name                                     old alloc/op   new alloc/op   delta
/BlobToKZGCommitment-8                      383kB ± 0%     383kB ± 0%     ~     (all equal)
/ComputeKZGProof-8                         1.04MB ± 0%    0.91MB ± 0%  -12.61%  (p=0.008 n=5+5)
/ComputeBlobKZGProof-8                     1.18MB ± 0%    0.91MB ± 0%  -22.94%  (p=0.008 n=5+5)
/VerifyKZGProof-8                          6.61kB ± 0%    6.61kB ± 0%     ~     (all equal)
/VerifyBlobKZGProof-8                       540kB ± 0%     400kB ± 0%  -25.80%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=1)-8         540kB ± 0%     401kB ± 0%  -25.79%  (p=0.000 n=5+4)
/VerifyBlobKZGProofBatch(count=2)-8        1.16MB ± 0%    0.88MB ± 0%  -23.94%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=4)-8        2.23MB ± 0%    1.68MB ± 0%  -24.95%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=8)-8        4.37MB ± 0%    3.26MB ± 0%  -25.48%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=16)-8       8.65MB ± 0%    6.42MB ± 0%  -25.76%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=32)-8       17.2MB ± 0%    12.8MB ± 0%  -25.90%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=64)-8       34.3MB ± 0%    25.4MB ± 0%  -25.99%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=1)-8      540kB ± 0%     401kB ± 0%  -25.79%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=2)-8     1.08MB ± 0%    0.80MB ± 0%  -25.79%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=4)-8     2.16MB ± 0%    1.60MB ± 0%  -25.79%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=8)-8     4.32MB ± 0%    3.21MB ± 0%  -25.79%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=16)-8    8.64MB ± 0%    6.41MB ± 0%  -25.79%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=32)-8    17.3MB ± 0%    12.8MB ± 0%  -25.79%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=64)-8    34.6MB ± 0%    25.6MB ± 0%  -25.79%  (p=0.008 n=5+5)

name                                     old allocs/op  new allocs/op  delta
/BlobToKZGCommitment-8                       74.0 ± 0%      74.0 ± 0%     ~     (all equal)
/ComputeKZGProof-8                           86.0 ± 0%      85.0 ± 0%   -1.16%  (p=0.008 n=5+5)
/ComputeBlobKZGProof-8                       94.0 ± 0%      92.0 ± 0%   -2.13%  (p=0.008 n=5+5)
/VerifyKZGProof-8                            50.0 ± 0%      50.0 ± 0%     ~     (all equal)
/VerifyBlobKZGProof-8                        60.0 ± 0%      59.0 ± 0%   -1.67%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=1)-8          62.0 ± 0%      61.0 ± 0%   -1.61%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=2)-8           496 ± 0%       494 ± 0%   -0.48%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=4)-8           551 ± 0%       546 ± 0%   -0.91%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=8)-8           656 ± 0%       647 ± 0%   -1.40%  (p=0.016 n=5+4)
/VerifyBlobKZGProofBatch(count=16)-8          842 ± 0%       822 ± 0%   -2.35%  (p=0.016 n=4+5)
/VerifyBlobKZGProofBatch(count=32)-8        1.22k ± 0%     1.18k ± 0%   -3.06%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=64)-8        1.91k ± 0%     1.84k ± 0%   -3.78%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=1)-8       63.0 ± 0%      62.0 ± 0%   -1.59%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=2)-8        128 ± 0%       126 ± 0%   -1.56%  (p=0.029 n=4+4)
/VerifyBlobKZGProofBatchPar(count=4)-8        258 ± 0%       253 ± 0%   -1.94%  (p=0.029 n=4+4)
/VerifyBlobKZGProofBatchPar(count=8)-8        515 ± 0%       506 ± 0%   -1.75%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=16)-8     1.02k ± 0%     1.01k ± 0%   -1.50%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=32)-8     2.06k ± 0%     2.02k ± 0%   -1.60%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatchPar(count=64)-8     4.12k ± 0%     4.05k ± 0%   -1.55%  (p=0.008 n=5+5)

```