### PR TITLE
perf: optimize `Verify` and `BatchVerifyMultiPoints` methods

### DIFF
--- a/internal/kzg/kzg_verify.go
+++ b/internal/kzg/kzg_verify.go
@@ -153,9 +153,9 @@ func BatchVerifyMultiPoints(commitments []Commitment, proofs []OpeningProof, ope
 	// `lhs` second pairing
 	foldedQuotients.Neg(&foldedQuotients)
 
-	check, err := bls12381.PairingCheck(
+	check, err := bls12381.PairingCheckFixedQ(
 		[]bls12381.G1Affine{foldedCommitments, foldedQuotients},
-		[]bls12381.G2Affine{openKey.GenG2, openKey.AlphaG2},
+		openKey.PairingLines[:],
 	)
 	if err != nil {
 		return err

--- a/internal/kzg/srs.go
+++ b/internal/kzg/srs.go
@@ -16,6 +16,8 @@ type OpeningKey struct {
 	// This is the degree-1 G_2 element in the trusted setup.
 	// In the specs, this is denoted as `KZG_SETUP_G2[1]`
 	AlphaG2 bls12381.G2Affine
+	// These are thr precomputed pairing lines corresponding to GenG2 and AlphaG2
+	PairingLines [2][2][len(bls12381.LoopCounter) - 1]bls12381.LineEvaluationAff
 }
 
 // CommitKey holds the data needed to commit to polynomials and by proxy make opening proofs

--- a/internal/kzg/srs.go
+++ b/internal/kzg/srs.go
@@ -16,7 +16,7 @@ type OpeningKey struct {
 	// This is the degree-1 G_2 element in the trusted setup.
 	// In the specs, this is denoted as `KZG_SETUP_G2[1]`
 	AlphaG2 bls12381.G2Affine
-	// These are thr precomputed pairing lines corresponding to GenG2 and AlphaG2
+	// These are the precomputed pairing lines corresponding to GenG2 and AlphaG2
 	PairingLines [2][2][len(bls12381.LoopCounter) - 1]bls12381.LineEvaluationAff
 }
 

--- a/internal/kzg/srs_insecure.go
+++ b/internal/kzg/srs_insecure.go
@@ -74,6 +74,8 @@ func newMonomialSRSInsecureUint64(size uint64, bAlpha *big.Int) (*SRS, error) {
 	openKey.GenG1 = gen1Aff
 	openKey.GenG2 = gen2Aff
 	openKey.AlphaG2.ScalarMultiplication(&gen2Aff, bAlpha)
+	openKey.PairingLines[0] = bls12381.PrecomputeLines(openKey.GenG2)
+	openKey.PairingLines[1] = bls12381.PrecomputeLines(openKey.AlphaG2)
 
 	alphas := make([]fr.Element, size-1)
 	alphas[0] = alpha


### PR DESCRIPTION
This PR ports two optimizations from gnark-crypto:
- Re-arranging the `Verify` pairing equation so that instead of doing a G1 scalar mul and a G2 scalar mul, we do a G1 2-MSM with Strauss-Shamir trick.
```go
// [f(z)]G₁ + [-z]([H(α)]G₁) = [f(z) - z*H(α)]G₁
```
- Re-arranging the pairing equations in `Verify` and `BatchVerifyMultiPoints` makes it possible to pre-compute the lines in pairing computation corresponding to `G₂` and `[α]G₂`
```go
 // e([f(α)-f(z)+aH(α)]G₁], G₂).e([-H(α)]G₁, [α]G₂) == 1
```
These pre-computed lines can be stored in the SRS.

## Bench
On a z1d.large AWS machine
```
goos: linux
goarch: amd64
pkg: github.com/crate-crypto/go-kzg-4844/internal/kzg
cpu: Intel(R) Xeon(R) Platinum 8151 CPU @ 3.40GHz
```

First optimisation saving for `Verify`:
```
benchmark                old ns/op     new ns/op     delta
BenchmarkKZGVerify-2     1121344       982636        -12.37%
```

The two optimisations combined:
```
benchmark                old ns/op     new ns/op     delta
BenchmarkKZGVerify-2     1121344       822792        -26.62%
```