### PR TITLE
Grammar and Style Improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ following commit: `017a8495f7671f5fff2075a9bfc9238c1a0982f8`
   version had a serialization bug.
   We only rely on gnark-crypto's underlying group operations and pairing code
   for bls12-381. For code that we do need to use, that has not been audited, we
-  have copied it into this library so that it can be a part of this libraries
+  have copied it into this library so that it can be a part of this library's
   audit. We have noted in the comments which functions we have done this for.
   
 
@@ -55,7 +55,7 @@ to only panic on startup; only methods which are called when we create the
 
 Because we use generics, the minimum golang version needs to be 1.18 or above. Since Golang only back ports security fixes to the latest version and one version behind latest, this library will at most be one version behind latest.
 
-Tests are ran against the 1.18, the current version and the latest version. If support for 1.18 is broken, we will update the CI to reflect this with a given reason.
+Tests are run against the 1.18, the current version and the latest version. If support for 1.18 is broken, we will update the CI to reflect this with a given reason.
 
 ## License
 

--- a/trusted_setup.go
+++ b/trusted_setup.go
@@ -73,7 +73,7 @@ func CheckTrustedSetupIsWellFormed(trustedSetup *JSONTrustedSetup) error {
 // which contains hex encoded strings to corresponding group elements.
 // Elements are assumed to be well-formed.
 //
-// This method wil panic if the points have not been serialized correctly.
+// This method will panic if the points have not been serialized correctly.
 func parseTrustedSetup(trustedSetup *JSONTrustedSetup) (bls12381.G1Affine, []bls12381.G1Affine, []bls12381.G2Affine) {
 	// The G1 generator is the first element of the monomial G1 points.
 	// We do not have that and so we use the fact that the setup started at


### PR DESCRIPTION
## Changes Made

### trusted_setup.go
- Old: `This method wil panic`
- New: `This method will panic`
- Reason: Fixed typo in "will" for correct spelling

### readme.md
- Old: `Tests are ran against`
- New: `Tests are run against`
- Reason: Corrected verb form - "run" is the correct form in passive voice

- Old: `libraries audit`
- New: `library's audit`
- Reason: Fixed possessive form using apostrophe