### PR TITLE
Pass blobs by pointer to VerifyBlobKZGProofBatch(Par)

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -74,7 +74,7 @@ func TestNonCanonicalSmoke(t *testing.T) {
 	err = ctx.VerifyBlobKZGProof(blobBad, commitment, blobProof)
 	require.Error(t, err, "expected an error since blob was not canonical")
 
-	err = ctx.VerifyBlobKZGProofBatch([]gokzg4844.Blob{*blobBad}, []gokzg4844.KZGCommitment{commitment}, []gokzg4844.KZGProof{blobProof})
+	err = ctx.VerifyBlobKZGProofBatch([]*gokzg4844.Blob{blobBad}, []gokzg4844.KZGCommitment{commitment}, []gokzg4844.KZGProof{blobProof})
 	require.Error(t, err, "expected an error since blob was not canonical")
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -47,7 +47,7 @@ func GetRandBlob(seed int64) *gokzg4844.Blob {
 
 func Benchmark(b *testing.B) {
 	const length = 64
-	blobs := make([]gokzg4844.Blob, length)
+	blobs := make([]*gokzg4844.Blob, length)
 	commitments := make([]gokzg4844.KZGCommitment, length)
 	proofs := make([]gokzg4844.KZGProof, length)
 	fields := make([]gokzg4844.Scalar, length)
@@ -59,7 +59,7 @@ func Benchmark(b *testing.B) {
 		proof, err := ctx.ComputeBlobKZGProof(blob, commitment, NumGoRoutines)
 		require.NoError(b, err)
 
-		blobs[i] = *blob
+		blobs[i] = blob
 		commitments[i] = commitment
 		proofs[i] = proof
 		fields[i] = GetRandFieldElement(int64(i))
@@ -72,21 +72,21 @@ func Benchmark(b *testing.B) {
 	b.Run("BlobToKZGCommitment", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
-			_, _ = ctx.BlobToKZGCommitment(&blobs[0], NumGoRoutines)
+			_, _ = ctx.BlobToKZGCommitment(blobs[0], NumGoRoutines)
 		}
 	})
 
 	b.Run("ComputeKZGProof", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
-			_, _, _ = ctx.ComputeKZGProof(&blobs[0], fields[0], NumGoRoutines)
+			_, _, _ = ctx.ComputeKZGProof(blobs[0], fields[0], NumGoRoutines)
 		}
 	})
 
 	b.Run("ComputeBlobKZGProof", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
-			_, _ = ctx.ComputeBlobKZGProof(&blobs[0], commitments[0], NumGoRoutines)
+			_, _ = ctx.ComputeBlobKZGProof(blobs[0], commitments[0], NumGoRoutines)
 		}
 	})
 
@@ -100,7 +100,7 @@ func Benchmark(b *testing.B) {
 	b.Run("VerifyBlobKZGProof", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
-			_ = ctx.VerifyBlobKZGProof(&blobs[0], commitments[0], proofs[0])
+			_ = ctx.VerifyBlobKZGProof(blobs[0], commitments[0], proofs[0])
 		}
 	})
 

--- a/consensus_specs_test.go
+++ b/consensus_specs_test.go
@@ -306,14 +306,14 @@ func TestVerifyBlobKZGProofBatch(t *testing.T) {
 			require.NoError(t, err)
 			testCaseValid := test.ProofIsValid != nil
 
-			var blobs []gokzg4844.Blob
+			var blobs []*gokzg4844.Blob
 			for _, b := range test.Input.Blobs {
 				blob, err := hexStrToBlob(b)
 				if err != nil {
 					require.False(t, testCaseValid)
 					return
 				}
-				blobs = append(blobs, *blob)
+				blobs = append(blobs, blob)
 			}
 
 			var commitments []gokzg4844.KZGCommitment

--- a/examples_test.go
+++ b/examples_test.go
@@ -33,7 +33,7 @@ func TestBlobProveVerifySpecifiedPointIntegration(t *testing.T) {
 
 func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 	batchSize := 5
-	blobs := make([]gokzg4844.Blob, batchSize)
+	blobs := make([]*gokzg4844.Blob, batchSize)
 	commitments := make([]gokzg4844.KZGCommitment, batchSize)
 	proofs := make([]gokzg4844.KZGProof, batchSize)
 
@@ -44,7 +44,7 @@ func TestBlobProveVerifyBatchIntegration(t *testing.T) {
 		proof, err := ctx.ComputeBlobKZGProof(blob, commitment, NumGoRoutines)
 		require.NoError(t, err)
 
-		blobs[i] = *blob
+		blobs[i] = blob
 		commitments[i] = commitment
 		proofs[i] = proof
 	}

--- a/verify.go
+++ b/verify.go
@@ -85,7 +85,7 @@ func (c *Context) VerifyBlobKZGProof(blob *Blob, blobCommitment KZGCommitment, k
 // VerifyBlobKZGProofBatch implements [verify_blob_kzg_proof_batch].
 //
 // [verify_blob_kzg_proof_batch]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
-func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []KZGCommitment, kzgProofs []KZGProof) error {
+func (c *Context) VerifyBlobKZGProofBatch(blobs []*Blob, polynomialCommitments []KZGCommitment, kzgProofs []KZGProof) error {
 	// 1. Check that all components in the batch have the same size
 	//
 	blobsLen := len(blobs)
@@ -114,7 +114,7 @@ func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []
 			return err
 		}
 
-		blob := &blobs[i]
+		blob := blobs[i]
 		polynomial, err := DeserializeBlob(blob)
 		if err != nil {
 			return err
@@ -149,7 +149,7 @@ func (c *Context) VerifyBlobKZGProofBatch(blobs []Blob, polynomialCommitments []
 // go-routines in a more intricate way than done below for large batches.
 //
 // [verify_blob_kzg_proof_batch]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
-func (c *Context) VerifyBlobKZGProofBatchPar(blobs []Blob, commitments []KZGCommitment, proofs []KZGProof) error {
+func (c *Context) VerifyBlobKZGProofBatchPar(blobs []*Blob, commitments []KZGCommitment, proofs []KZGProof) error {
 	// 1. Check that all components in the batch have the same size
 	if len(commitments) != len(blobs) || len(proofs) != len(blobs) {
 		return ErrBatchLengthCheck
@@ -160,7 +160,7 @@ func (c *Context) VerifyBlobKZGProofBatchPar(blobs []Blob, commitments []KZGComm
 	for i := range blobs {
 		j := i // Capture the value of the loop variable
 		errG.Go(func() error {
-			return c.VerifyBlobKZGProof(&blobs[j], commitments[j], proofs[j])
+			return c.VerifyBlobKZGProof(blobs[j], commitments[j], proofs[j])
 		})
 	}
 


### PR DESCRIPTION
Performance optimization. Allows to avoid copying heavy blobs when the caller uses data structures other than `[]Blob`. Extension of https://github.com/crate-crypto/go-kzg-4844/commit/51e065ee3a14d919c37f3d94ab86f4b5602c608c. 